### PR TITLE
implement CPLEX LP file parser

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,8 +39,8 @@ Target: **Q3.** Backwards-compatible additions only. Epic: [#24](https://github.
 
 - **Reading** `.lp` and `.mps` files (writers ship in v0.1; readers come
   next so models can flow in from MIPLIB benchmarks).
-  ([#1](https://github.com/JakenHerman/grove/issues/1) CPLEX LP ·
-  [#2](https://github.com/JakenHerman/grove/issues/2) MPS)
+  - [x] [#1](https://github.com/JakenHerman/grove/issues/1) CPLEX LP
+  - [ ] [#2](https://github.com/JakenHerman/grove/issues/2) MPS
 - Range information for sensitivity: per-coefficient and per-RHS ranges
   over which the current basis stays optimal (Bertsimas & Tsitsiklis §5.2).
   ([#3](https://github.com/JakenHerman/grove/issues/3))

--- a/docs/guide/api-reference.html
+++ b/docs/guide/api-reference.html
@@ -285,6 +285,10 @@
           <span class="sig">func (p *Problem) WriteMPS(w io.Writer) error</span>
           <p>Writes the problem in fixed-column MPS format.</p>
         </div>
+        <div class="def">
+          <span class="sig">func ReadLP(r io.Reader) (*Problem, error)</span>
+          <p>Parses a problem from CPLEX-LP format — the inverse of <code>WriteLP</code>. Accepts the usual tolerances (case-insensitive keywords, abbreviated headers, multi-line expressions, backslash comments, blank lines anywhere). Parse errors are annotated with the 1-based line and column.</p>
+        </div>
       </div>
 
       <h2>Result</h2>

--- a/docs/guide/api-reference.html
+++ b/docs/guide/api-reference.html
@@ -287,7 +287,14 @@
         </div>
         <div class="def">
           <span class="sig">func ReadLP(r io.Reader) (*Problem, error)</span>
-          <p>Parses a problem from CPLEX-LP format — the inverse of <code>WriteLP</code>. Accepts the usual tolerances (case-insensitive keywords, abbreviated headers, multi-line expressions, backslash comments, blank lines anywhere). Parse errors are annotated with the 1-based line and column.</p>
+          <p>Parses a problem from CPLEX-LP format — the inverse of <code>WriteLP</code>. Accepts the usual tolerances (case-insensitive keywords, abbreviated headers, multi-line expressions, backslash comments, blank lines anywhere). Parse errors are returned as <code>*grove.ParseError</code>; see below.</p>
+        </div>
+        <div class="def">
+          <span class="sig">type ParseError struct {
+  Line, Col int
+  Msg       string
+}</span>
+          <p>Structured error returned by <code>ReadLP</code>. <code>Line</code> is 1-based; <code>Col</code> is 1-based when the position inside a line is meaningful and <code>0</code> otherwise. Extract with <code>errors.As</code> to drive editor highlights, etc. <code>Error()</code> folds the prefix <code>"grove: LP parse error …"</code> around <code>Msg</code>.</p>
         </div>
       </div>
 

--- a/docs/guide/file-io.html
+++ b/docs/guide/file-io.html
@@ -130,13 +130,25 @@ res, err := prob.Solve()
       </p>
 
       <p>
-        Parse errors are <code>*grove.parseError</code> values whose
+        Parse errors are <code>*grove.ParseError</code> values whose
         <code>Error()</code> includes the 1-based line (and column when
         available) so mistakes surface with a useful pointer into the
         file:
       </p>
 
 <pre><code>grove: LP parse error at line 5, column 11: expected '+' or '-' between terms
+</code></pre>
+
+      <p>
+        The <code>Line</code>, <code>Col</code>, and <code>Msg</code>
+        fields are exported, so tooling can pull them out with
+        <code>errors.As</code> to underline the offending spot:
+      </p>
+
+<pre><code class="language-go">var pe *grove.ParseError
+if errors.As(err, &amp;pe) {
+    highlight(path, pe.Line, pe.Col)
+}
 </code></pre>
 
       <p>

--- a/docs/guide/file-io.html
+++ b/docs/guide/file-io.html
@@ -93,6 +93,60 @@ End
         grove.
       </p>
 
+      <h3>Reading LP files</h3>
+
+      <p>
+        <code>grove.ReadLP</code> is the inverse of
+        <code>WriteLP</code>: any model you write with <code>WriteLP</code>
+        and read back with <code>ReadLP</code> is structurally
+        equivalent to the original — same sense, same variable
+        kinds/bounds, same objective and constraint coefficients.
+      </p>
+
+<pre><code class="language-go">f, err := os.Open("nurses.lp")
+if err != nil {
+    return err
+}
+defer f.Close()
+
+prob, err := grove.ReadLP(f)
+if err != nil {
+    return err // parse errors carry the offending line and column
+}
+
+res, err := prob.Solve()
+</code></pre>
+
+      <p>
+        The reader accepts the usual CPLEX-LP tolerances: case-insensitive
+        keywords, abbreviated section headers (<code>Min</code>/<code>Max</code>,
+        <code>s.t.</code>/<code>st</code>/<code>such that</code>,
+        <code>Bound</code>, <code>Gen</code>/<code>Integer</code>/<code>Integers</code>,
+        <code>Bin</code>/<code>Binaries</code>), expressions that span
+        multiple lines, backslash comments, and blank lines anywhere.
+        Variables that appear only in the objective or constraints —
+        without an explicit <code>Bounds</code> row — default to
+        <code>[0, +Inf]</code> continuous, matching the CPLEX default.
+      </p>
+
+      <p>
+        Parse errors are <code>*grove.parseError</code> values whose
+        <code>Error()</code> includes the 1-based line (and column when
+        available) so mistakes surface with a useful pointer into the
+        file:
+      </p>
+
+<pre><code>grove: LP parse error at line 5, column 11: expected '+' or '-' between terms
+</code></pre>
+
+      <p>
+        The reader does not yet model SOS sets (they are silently
+        skipped) or <em>range constraints</em> of the form
+        <code>3 &lt;= expr &lt;= 10</code> — the latter surface a clear
+        diagnostic. If you need ranges today, split them into two
+        separate constraints.
+      </p>
+
       <h2>MPS format</h2>
 
       <p>
@@ -124,10 +178,10 @@ if err := prob.WriteMPS(f); err != nil {
       <div class="callout">
         <span class="callout-label">roadmap</span>
         <p>
-          MPS and LP <em>readers</em> land in v0.2, which will close
-          the round-trip. v0.1 ships only the writers because the
-          immediate use-case is &ldquo;hand my model to CBC or
-          HiGHS&rdquo;.
+          The CPLEX-LP reader (<code>ReadLP</code>) shipped in v0.2 and
+          is documented above. The MPS reader is the next v0.2 item —
+          until it lands, models authored in MPS need a detour through
+          an LP converter.
         </p>
       </div>
 

--- a/reader.go
+++ b/reader.go
@@ -41,9 +41,13 @@ import (
 // The parser accepts the standard section-based LP grammar with common
 // tolerances: case-insensitive keywords, abbreviated forms (Min/Max,
 // s.t./st/such that, Bound, Gen/Integer/Integers, Bin/Binaries),
-// backslash comments, and blank lines anywhere. Unknown sections (e.g.
-// SOS) are skipped rather than rejected. Undeclared variables default
-// to [0, +Inf] continuous, matching the CPLEX default.
+// backslash comments, and blank lines anywhere. SOS sections are
+// recognized and silently skipped — grove does not model SOS sets
+// yet — but any other header grove does not know about is reported as
+// a parse error rather than silently dropped, so typos like
+// "Subkect To" don't quietly swallow a whole constraints block.
+// Undeclared variables default to [0, +Inf] continuous, matching the
+// CPLEX default.
 //
 // Input is consumed via a buffered line-by-line scan, so very large
 // files (e.g. MIPLIB instances) do not need to be held in memory all

--- a/reader.go
+++ b/reader.go
@@ -26,6 +26,7 @@ package grove
 // to make mistakes easy to locate.
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"math"
@@ -43,12 +44,13 @@ import (
 // backslash comments, and blank lines anywhere. Unknown sections (e.g.
 // SOS) are skipped rather than rejected. Undeclared variables default
 // to [0, +Inf] continuous, matching the CPLEX default.
+//
+// Input is consumed via a buffered line-by-line scan, so very large
+// files (e.g. MIPLIB instances) do not need to be held in memory all
+// at once — peak allocation is bounded by the largest single section's
+// body plus the resulting *Problem.
 func ReadLP(r io.Reader) (*Problem, error) {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-	return parseLP(string(data))
+	return parseLP(r)
 }
 
 // ParseError is the error type returned by [ReadLP] for malformed
@@ -115,39 +117,95 @@ type section struct {
 	body   []srcLine
 }
 
-// splitSections walks the raw source and slices it at section headers.
-// Each returned section carries the body lines (with comments stripped)
-// between its own header and the next header. The initial (pre-header)
-// slice is returned as a secNone section and is expected to be empty
-// for well-formed input.
-func splitSections(src string) []section {
-	raw := strings.Split(src, "\n")
-	lines := make([]srcLine, 0, len(raw))
-	for i, s := range raw {
-		if j := strings.IndexByte(s, '\\'); j >= 0 {
-			s = s[:j]
-		}
-		s = strings.TrimRight(s, "\r")
-		lines = append(lines, srcLine{text: s, no: i + 1})
-	}
+// lineStream yields one source line at a time from an [io.Reader],
+// stripping trailing CR and backslash comments while tracking the
+// 1-based line number. It lets the parser walk huge LP files without
+// ever holding the full source in memory.
+type lineStream struct {
+	sc *bufio.Scanner
+	no int
+}
 
-	var sections []section
-	cur := section{kind: secNone}
-	for _, l := range lines {
-		trimmed := strings.TrimSpace(l.text)
-		if trimmed == "" {
-			cur.body = append(cur.body, l)
-			continue
+// maxLineBytes caps how long a single LP source line may be. The
+// Scanner default of 64 KiB is easily exceeded by the objective row of
+// a large MIPLIB instance, so we raise the ceiling to 16 MiB — big
+// enough for anything we've seen in practice, small enough to guard
+// against pathological input.
+const maxLineBytes = 16 << 20
+
+func newLineStream(r io.Reader) *lineStream {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
+	return &lineStream{sc: sc}
+}
+
+// next returns the next source line (comments stripped), a flag that
+// is false at EOF, and any underlying read error. The returned
+// srcLine.text is an independent allocation, safe to retain across
+// subsequent calls.
+func (l *lineStream) next() (srcLine, bool, error) {
+	if !l.sc.Scan() {
+		if err := l.sc.Err(); err != nil {
+			return srcLine{}, false, err
 		}
-		if kind, ok := matchSectionHeader(trimmed); ok {
-			sections = append(sections, cur)
-			cur = section{kind: kind, header: l.no}
-			continue
-		}
-		cur.body = append(cur.body, l)
+		return srcLine{}, false, nil
 	}
-	sections = append(sections, cur)
-	return sections
+	l.no++
+	raw := l.sc.Text()
+	if i := strings.IndexByte(raw, '\\'); i >= 0 {
+		raw = raw[:i]
+	}
+	raw = strings.TrimRight(raw, "\r")
+	return srcLine{text: raw, no: l.no}, true, nil
+}
+
+// nextHeader reads through any blank/comment-only lines until it finds
+// a section header or EOF. A non-empty, non-header line before any
+// header is a structural error. At EOF the returned kind is secNone
+// and no error is reported.
+func (l *lineStream) nextHeader() (sectionKind, int, error) {
+	for {
+		line, ok, err := l.next()
+		if err != nil {
+			return secNone, 0, err
+		}
+		if !ok {
+			return secNone, 0, nil
+		}
+		trimmed := strings.TrimSpace(line.text)
+		if trimmed == "" {
+			continue
+		}
+		if k, isH := matchSectionHeader(trimmed); isH {
+			return k, line.no, nil
+		}
+		return secNone, 0, errAt(line.no, 1, "content before Minimize/Maximize header")
+	}
+}
+
+// readSectionBody consumes lines for the current section until it hits
+// the next section header or EOF. It returns the accumulated body,
+// the kind and 1-based line number of the next header (secNone/0 at
+// EOF), and any scanner error.
+func readSectionBody(ls *lineStream) (body []srcLine, nextKind sectionKind, nextHeader int, err error) {
+	for {
+		line, ok, lerr := ls.next()
+		if lerr != nil {
+			return body, secNone, 0, lerr
+		}
+		if !ok {
+			return body, secNone, 0, nil
+		}
+		trimmed := strings.TrimSpace(line.text)
+		if trimmed == "" {
+			body = append(body, line)
+			continue
+		}
+		if k, isH := matchSectionHeader(trimmed); isH {
+			return body, k, line.no, nil
+		}
+		body = append(body, line)
+	}
 }
 
 // matchSectionHeader returns the section kind for a line that is
@@ -866,87 +924,86 @@ func hasContent(body []srcLine) bool {
 // picks up the objective sense, then hands each section to the
 // appropriate parser. The order mirrors the LP file format: objective,
 // then Subject To, then Bounds, then General/Binary, then End.
-func parseLP(src string) (*Problem, error) {
-	sections := splitSections(src)
+// parseLP streams LP source from r one section at a time. Objective,
+// Subject To, and Bounds sections are parsed inline as soon as their
+// bodies finish, so their source bytes are released before the next
+// section begins. General and Binary sections hold only identifier
+// names, so they are buffered and applied last — that way Binary's
+// bound-pinning wins over any earlier Bounds rows regardless of the
+// order they appear in the file (which matches the previous
+// collect-then-process driver).
+func parseLP(r io.Reader) (*Problem, error) {
+	ls := newLineStream(r)
+
+	firstKind, firstHeader, err := ls.nextHeader()
+	if err != nil {
+		return nil, err
+	}
 
 	var sense Sense
-	var senseFound bool
-	var objSection section
-	var stSection section
-	var boundsSection section
-	var generalSections []section
-	var binarySections []section
-
-	for _, sec := range sections {
-		switch sec.kind {
-		case secNone:
-			// Accept only empty preambles / trailing regions. A
-			// non-empty sectionless block is a structural error.
-			if hasContent(sec.body) && senseFound {
-				continue // tolerate trailing junk after End
-			}
-			if hasContent(sec.body) {
-				l := sec.body[0]
-				return nil, errAt(l.no, 1, "content before Minimize/Maximize header")
-			}
-		case secMin:
-			if senseFound {
-				return nil, errAt(sec.header, 0, "duplicate objective section")
-			}
-			sense = Minimize
-			senseFound = true
-			objSection = sec
-		case secMax:
-			if senseFound {
-				return nil, errAt(sec.header, 0, "duplicate objective section")
-			}
-			sense = Maximize
-			senseFound = true
-			objSection = sec
-		case secST:
-			stSection = sec
-		case secBounds:
-			boundsSection = sec
-		case secGeneral:
-			generalSections = append(generalSections, sec)
-		case secBinary:
-			binarySections = append(binarySections, sec)
-		case secSOS:
-			// Silently skip — grove does not model SOS sets (yet).
-		case secEnd:
-			// Stop looking at further content; LP format sanctions
-			// whatever appears after End.
-			goto done
-		}
-	}
-done:
-
-	if !senseFound {
+	switch firstKind {
+	case secNone:
 		return nil, &ParseError{Msg: "missing Minimize/Maximize section"}
+	case secMin:
+		sense = Minimize
+	case secMax:
+		sense = Maximize
+	default:
+		return nil, errAt(firstHeader, 0, "missing Minimize/Maximize section")
 	}
 
 	prob := NewProblem("", sense)
 	b := &builder{prob: prob, vars: map[string]*Var{}}
 
-	if err := b.parseObjective(objSection); err != nil {
-		return nil, err
-	}
-	if stSection.kind == secST {
-		if err := b.parseConstraints(stSection); err != nil {
-			return nil, err
+	var generalSecs, binarySecs []section
+	curKind := firstKind
+	curHeader := firstHeader
+	for curKind != secEnd {
+		body, nextKind, nextHeader, berr := readSectionBody(ls)
+		if berr != nil {
+			return nil, berr
 		}
-	}
-	if boundsSection.kind == secBounds {
-		if err := b.parseBounds(boundsSection); err != nil {
-			return nil, err
+		sec := section{kind: curKind, header: curHeader, body: body}
+		switch curKind {
+		case secMin, secMax:
+			if err := b.parseObjective(sec); err != nil {
+				return nil, err
+			}
+		case secST:
+			if err := b.parseConstraints(sec); err != nil {
+				return nil, err
+			}
+		case secBounds:
+			if err := b.parseBounds(sec); err != nil {
+				return nil, err
+			}
+		case secGeneral:
+			generalSecs = append(generalSecs, sec)
+		case secBinary:
+			binarySecs = append(binarySecs, sec)
+		case secSOS:
+			// Silently skip — grove does not model SOS sets (yet).
 		}
+
+		if nextKind == secNone || nextKind == secEnd {
+			// Either EOF or an explicit End marker: the LP format
+			// sanctions whatever appears after End, so we stop
+			// reading.
+			break
+		}
+		if nextKind == secMin || nextKind == secMax {
+			return nil, errAt(nextHeader, 0, "duplicate objective section")
+		}
+		curKind = nextKind
+		curHeader = nextHeader
 	}
-	for _, g := range generalSections {
+
+	for _, g := range generalSecs {
 		if err := b.parseVarList(g, Integer); err != nil {
 			return nil, err
 		}
 	}
-	for _, bn := range binarySections {
+	for _, bn := range binarySecs {
 		if err := b.parseVarList(bn, Binary); err != nil {
 			return nil, err
 		}

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,921 @@
+package grove
+
+// CPLEX LP-format parser. The round-trip contract:
+//
+//	WriteLP  writes a grove *Problem to CPLEX LP format.
+//	ReadLP   reads CPLEX LP format back into a grove *Problem.
+//
+// A model flowed through WriteLP → ReadLP is structurally equivalent
+// to the original: same sense, same variable names/kinds/bounds, same
+// objective coefficients and constant, same constraint coefficients,
+// relations, and right-hand sides. Declaration order is preserved when
+// every variable appears in the objective (which is how WriteLP orders
+// its output).
+//
+// The grammar accepted here is the CPLEX LP section-based grammar
+// (Minimize/Maximize, Subject To, Bounds, General, Binary, End), with
+// the usual tolerances: section headers are case-insensitive and may be
+// abbreviated (Min/Max, s.t./st/such that, Bound, Gen/Integer/Integers,
+// Bin/Binaries). Comments start with "\" and run to end of line. Blank
+// lines are allowed anywhere. Variable names that are never declared
+// in a Bounds, General, or Binary section default to a non-negative
+// continuous variable (lower bound 0, upper bound +Inf) — matching the
+// CPLEX default.
+//
+// Parse errors carry a 1-based line number (and column, when available)
+// to make mistakes easy to locate.
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// ReadLP parses a CPLEX LP-format problem from r. It is the inverse of
+// [Problem.WriteLP]: any grove model written with WriteLP and read back
+// with ReadLP produces an equivalent *Problem.
+//
+// The parser accepts the standard section-based LP grammar with common
+// tolerances: case-insensitive keywords, abbreviated forms (Min/Max,
+// s.t./st/such that, Bound, Gen/Integer/Integers, Bin/Binaries),
+// backslash comments, and blank lines anywhere. Unknown sections (e.g.
+// SOS) are skipped rather than rejected. Undeclared variables default
+// to [0, +Inf] continuous, matching the CPLEX default.
+func ReadLP(r io.Reader) (*Problem, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return parseLP(string(data))
+}
+
+// parseError carries a 1-based line and column so the caller can point
+// the user at the offending spot.
+type parseError struct {
+	Line, Col int
+	Msg       string
+}
+
+func (e *parseError) Error() string {
+	switch {
+	case e.Col > 0 && e.Line > 0:
+		return fmt.Sprintf("grove: LP parse error at line %d, column %d: %s", e.Line, e.Col, e.Msg)
+	case e.Line > 0:
+		return fmt.Sprintf("grove: LP parse error at line %d: %s", e.Line, e.Msg)
+	default:
+		return "grove: LP parse error: " + e.Msg
+	}
+}
+
+func errAt(line, col int, format string, args ...any) *parseError {
+	return &parseError{Line: line, Col: col, Msg: fmt.Sprintf(format, args...)}
+}
+
+// srcLine is an input line with its original 1-based line number.
+// Comments have already been stripped by the time one of these lands
+// in a section body.
+type srcLine struct {
+	text string
+	no   int
+}
+
+type sectionKind int
+
+const (
+	secNone sectionKind = iota
+	secMin
+	secMax
+	secST
+	secBounds
+	secGeneral
+	secBinary
+	secSOS
+	secEnd
+)
+
+type section struct {
+	kind   sectionKind
+	header int // 1-based line of the header keyword
+	body   []srcLine
+}
+
+// splitSections walks the raw source and slices it at section headers.
+// Each returned section carries the body lines (with comments stripped)
+// between its own header and the next header. The initial (pre-header)
+// slice is returned as a secNone section and is expected to be empty
+// for well-formed input.
+func splitSections(src string) []section {
+	raw := strings.Split(src, "\n")
+	lines := make([]srcLine, 0, len(raw))
+	for i, s := range raw {
+		if j := strings.IndexByte(s, '\\'); j >= 0 {
+			s = s[:j]
+		}
+		s = strings.TrimRight(s, "\r")
+		lines = append(lines, srcLine{text: s, no: i + 1})
+	}
+
+	var sections []section
+	cur := section{kind: secNone}
+	for _, l := range lines {
+		trimmed := strings.TrimSpace(l.text)
+		if trimmed == "" {
+			cur.body = append(cur.body, l)
+			continue
+		}
+		if kind, ok := matchSectionHeader(trimmed); ok {
+			sections = append(sections, cur)
+			cur = section{kind: kind, header: l.no}
+			continue
+		}
+		cur.body = append(cur.body, l)
+	}
+	sections = append(sections, cur)
+	return sections
+}
+
+// matchSectionHeader returns the section kind for a line that is
+// entirely a section header, case-insensitive and whitespace-insensitive.
+// All the variant spellings the wild sees are accepted.
+func matchSectionHeader(line string) (sectionKind, bool) {
+	norm := strings.ToLower(strings.Join(strings.Fields(line), " "))
+	switch norm {
+	case "minimize", "minimise", "min":
+		return secMin, true
+	case "maximize", "maximise", "max":
+		return secMax, true
+	case "subject to", "such that", "s.t.", "st.", "st":
+		return secST, true
+	case "bounds", "bound":
+		return secBounds, true
+	case "general", "generals", "gen", "integer", "integers":
+		return secGeneral, true
+	case "binary", "binaries", "bin":
+		return secBinary, true
+	case "sos":
+		return secSOS, true
+	case "end":
+		return secEnd, true
+	}
+	return secNone, false
+}
+
+// ── Tokenizer ─────────────────────────────────────────────────────────
+
+type tokType int
+
+const (
+	tokEOF tokType = iota
+	tokIdent
+	tokNumber
+	tokColon
+	tokPlus
+	tokMinus
+	tokStar
+	tokLE
+	tokGE
+	tokEQ
+)
+
+type token struct {
+	typ       tokType
+	text      string
+	num       float64
+	line, col int
+}
+
+type tokenizer struct {
+	lines []srcLine
+	i     int
+	j     int
+}
+
+func newTokenizer(body []srcLine) *tokenizer {
+	return &tokenizer{lines: body}
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+// isStructural reports whether c is a character with its own syntactic
+// role (whitespace or one of the LP operators).
+func isStructural(c byte) bool {
+	switch c {
+	case ' ', '\t', '\r', '\n', '+', '-', '*', '<', '>', '=', ':', '\\':
+		return true
+	}
+	return false
+}
+
+// isIdentStart/isIdentPart follow the CPLEX LP convention: identifiers
+// may use most punctuation except the structural operators and must not
+// start with a digit or a period (which would collide with numeric
+// literals).
+func isIdentStart(c byte) bool {
+	if isStructural(c) || isDigit(c) || c == '.' {
+		return false
+	}
+	return true
+}
+
+func isIdentPart(c byte) bool { return !isStructural(c) }
+
+func (t *tokenizer) next() (token, error) {
+	for t.i < len(t.lines) {
+		line := t.lines[t.i].text
+		for t.j < len(line) && (line[t.j] == ' ' || line[t.j] == '\t' || line[t.j] == '\r') {
+			t.j++
+		}
+		if t.j >= len(line) {
+			t.i++
+			t.j = 0
+			continue
+		}
+		c := line[t.j]
+		lno := t.lines[t.i].no
+		col := t.j + 1
+		switch {
+		case c == ':':
+			t.j++
+			return token{typ: tokColon, line: lno, col: col}, nil
+		case c == '+':
+			t.j++
+			return token{typ: tokPlus, line: lno, col: col}, nil
+		case c == '-':
+			t.j++
+			return token{typ: tokMinus, line: lno, col: col}, nil
+		case c == '*':
+			t.j++
+			return token{typ: tokStar, line: lno, col: col}, nil
+		case c == '<':
+			t.j++
+			if t.j < len(line) && line[t.j] == '=' {
+				t.j++
+			}
+			return token{typ: tokLE, line: lno, col: col}, nil
+		case c == '>':
+			t.j++
+			if t.j < len(line) && line[t.j] == '=' {
+				t.j++
+			}
+			return token{typ: tokGE, line: lno, col: col}, nil
+		case c == '=':
+			t.j++
+			if t.j < len(line) {
+				if line[t.j] == '<' {
+					t.j++
+					return token{typ: tokLE, line: lno, col: col}, nil
+				}
+				if line[t.j] == '>' {
+					t.j++
+					return token{typ: tokGE, line: lno, col: col}, nil
+				}
+			}
+			return token{typ: tokEQ, line: lno, col: col}, nil
+		case isDigit(c) || c == '.':
+			return t.readNumber(lno, col)
+		case isIdentStart(c):
+			return t.readIdent(lno, col)
+		default:
+			t.j++
+			return token{}, errAt(lno, col, "unexpected character %q", c)
+		}
+	}
+	return token{typ: tokEOF}, nil
+}
+
+func (t *tokenizer) readNumber(lno, col int) (token, error) {
+	line := t.lines[t.i].text
+	start := t.j
+	sawDot := false
+	for t.j < len(line) {
+		c := line[t.j]
+		if isDigit(c) {
+			t.j++
+			continue
+		}
+		if c == '.' && !sawDot {
+			sawDot = true
+			t.j++
+			continue
+		}
+		break
+	}
+	if t.j < len(line) && (line[t.j] == 'e' || line[t.j] == 'E') {
+		t.j++
+		if t.j < len(line) && (line[t.j] == '+' || line[t.j] == '-') {
+			t.j++
+		}
+		for t.j < len(line) && isDigit(line[t.j]) {
+			t.j++
+		}
+	}
+	txt := line[start:t.j]
+	n, err := strconv.ParseFloat(txt, 64)
+	if err != nil {
+		return token{}, errAt(lno, col, "invalid number %q", txt)
+	}
+	return token{typ: tokNumber, text: txt, num: n, line: lno, col: col}, nil
+}
+
+func (t *tokenizer) readIdent(lno, col int) (token, error) {
+	line := t.lines[t.i].text
+	start := t.j
+	for t.j < len(line) && isIdentPart(line[t.j]) {
+		t.j++
+	}
+	return token{typ: tokIdent, text: line[start:t.j], line: lno, col: col}, nil
+}
+
+// ── Parser ────────────────────────────────────────────────────────────
+
+type parser struct {
+	tok *tokenizer
+	buf []token // fixed-size-ish peek buffer
+}
+
+func (p *parser) peekN(n int) (token, error) {
+	for len(p.buf) <= n {
+		t, err := p.tok.next()
+		if err != nil {
+			return token{}, err
+		}
+		p.buf = append(p.buf, t)
+		if t.typ == tokEOF {
+			break
+		}
+	}
+	if n >= len(p.buf) {
+		return p.buf[len(p.buf)-1], nil
+	}
+	return p.buf[n], nil
+}
+
+func (p *parser) peek() (token, error) { return p.peekN(0) }
+
+func (p *parser) consume() (token, error) {
+	if len(p.buf) > 0 {
+		t := p.buf[0]
+		p.buf = p.buf[1:]
+		return t, nil
+	}
+	return p.tok.next()
+}
+
+// expectEOF fails if the stream isn't at EOF. Used after parsing a
+// bound statement to flag stray trailing tokens.
+func (p *parser) expectEOF() error {
+	t, err := p.consume()
+	if err != nil {
+		return err
+	}
+	if t.typ != tokEOF {
+		text := t.text
+		if text == "" {
+			text = symbolName(t.typ)
+		}
+		return errAt(t.line, t.col, "unexpected trailing %q", text)
+	}
+	return nil
+}
+
+// symbolName is a display helper for tokens that carry no literal text.
+func symbolName(t tokType) string {
+	switch t {
+	case tokPlus:
+		return "+"
+	case tokMinus:
+		return "-"
+	case tokStar:
+		return "*"
+	case tokColon:
+		return ":"
+	case tokLE:
+		return "<="
+	case tokGE:
+		return ">="
+	case tokEQ:
+		return "="
+	case tokEOF:
+		return "<eof>"
+	}
+	return "<token>"
+}
+
+// isInfinityWord recognises the various spellings of infinity that
+// appear in the Bounds section.
+func isInfinityWord(s string) bool {
+	switch strings.ToLower(s) {
+	case "inf", "infinity", "infty":
+		return true
+	}
+	return false
+}
+
+// parseSignedNumber reads an optional +/- and a numeric literal (or an
+// infinity keyword). Used for right-hand sides and bound values.
+func (p *parser) parseSignedNumber() (float64, error) {
+	sign := 1.0
+	t, err := p.peek()
+	if err != nil {
+		return 0, err
+	}
+	switch t.typ {
+	case tokPlus:
+		_, _ = p.consume()
+	case tokMinus:
+		_, _ = p.consume()
+		sign = -1
+	}
+	t, err = p.consume()
+	if err != nil {
+		return 0, err
+	}
+	switch t.typ {
+	case tokNumber:
+		return sign * t.num, nil
+	case tokIdent:
+		if isInfinityWord(t.text) {
+			if sign < 0 {
+				return math.Inf(-1), nil
+			}
+			return math.Inf(1), nil
+		}
+	}
+	return 0, errAt(t.line, t.col, "expected number, got %q", t.text)
+}
+
+// parseExprAndConst reads a linear expression (a sum of signed terms)
+// and returns the sparse coefficient map along with any constant terms.
+// Parsing stops at a relation operator (<=, >=, =), a colon, or EOF.
+//
+// First term's sign is optional; subsequent terms must be separated by
+// an explicit + or -. A "term" is either `[coef] [*] ident` (a linear
+// term) or a bare number (a constant contribution). The `*` between
+// coefficient and variable is optional, matching the CPLEX LP grammar.
+func (p *parser) parseExprAndConst(b *builder) (Expr, float64, error) {
+	expr := Expr{}
+	constant := 0.0
+	first := true
+
+	for {
+		sign := 1.0
+		hasSign := false
+		t, err := p.peek()
+		if err != nil {
+			return nil, 0, err
+		}
+		switch t.typ {
+		case tokPlus:
+			_, _ = p.consume()
+			hasSign = true
+		case tokMinus:
+			_, _ = p.consume()
+			sign = -1
+			hasSign = true
+		}
+
+		t, err = p.peek()
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if !first && !hasSign {
+			switch t.typ {
+			case tokLE, tokGE, tokEQ, tokColon, tokEOF:
+				return expr, constant, nil
+			default:
+				return nil, 0, errAt(t.line, t.col, "expected '+' or '-' between terms")
+			}
+		}
+		if hasSign {
+			switch t.typ {
+			case tokLE, tokGE, tokEQ, tokColon, tokEOF:
+				return nil, 0, errAt(t.line, t.col, "dangling sign")
+			}
+		} else {
+			switch t.typ {
+			case tokLE, tokGE, tokEQ, tokColon, tokEOF:
+				return expr, constant, nil
+			}
+		}
+
+		coef := 1.0
+		haveCoef := false
+		if t.typ == tokNumber {
+			coef = t.num
+			haveCoef = true
+			_, _ = p.consume()
+			t2, err := p.peek()
+			if err != nil {
+				return nil, 0, err
+			}
+			if t2.typ == tokStar {
+				_, _ = p.consume()
+			}
+		}
+
+		t3, err := p.peek()
+		if err != nil {
+			return nil, 0, err
+		}
+		switch {
+		case t3.typ == tokIdent:
+			_, _ = p.consume()
+			v := b.getVar(t3.text)
+			expr[v] += sign * coef
+		case haveCoef:
+			constant += sign * coef
+		default:
+			return nil, 0, errAt(t3.line, t3.col, "expected number or identifier")
+		}
+		first = false
+	}
+}
+
+// ── builder ───────────────────────────────────────────────────────────
+
+// builder tracks the problem under construction, creating variables on
+// first mention with default bounds (0, +Inf) and continuous kind. The
+// Bounds, General, and Binary sections later adjust bounds and kinds
+// in place.
+type builder struct {
+	prob *Problem
+	vars map[string]*Var
+}
+
+func (b *builder) getVar(name string) *Var {
+	if v, ok := b.vars[name]; ok {
+		return v
+	}
+	v := b.prob.NewVar(name, Continuous)
+	b.vars[name] = v
+	return v
+}
+
+// ── Section parsers ───────────────────────────────────────────────────
+
+func (b *builder) parseObjective(sec section) error {
+	if !hasContent(sec.body) {
+		return errAt(sec.header, 0, "missing objective expression")
+	}
+	p := &parser{tok: newTokenizer(sec.body)}
+
+	// Optional "label:" prefix.
+	t1, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if t1.typ == tokIdent {
+		t2, err := p.peekN(1)
+		if err != nil {
+			return err
+		}
+		if t2.typ == tokColon {
+			_, _ = p.consume() // label ident
+			_, _ = p.consume() // colon
+		}
+	}
+
+	expr, constant, err := p.parseExprAndConst(b)
+	if err != nil {
+		return err
+	}
+	t, err := p.consume()
+	if err != nil {
+		return err
+	}
+	if t.typ != tokEOF {
+		return errAt(t.line, t.col, "unexpected token %q in objective", t.text)
+	}
+	// Overwrite the objective directly — SetObjective would re-copy and
+	// re-validate, but we know every *Var was just produced by b.getVar.
+	b.prob.objective = expr
+	b.prob.objConst = constant
+	return nil
+}
+
+func (b *builder) parseConstraints(sec section) error {
+	if !hasContent(sec.body) {
+		return nil
+	}
+	p := &parser{tok: newTokenizer(sec.body)}
+	anon := 0
+	for {
+		t, err := p.peek()
+		if err != nil {
+			return err
+		}
+		if t.typ == tokEOF {
+			return nil
+		}
+
+		// Optional "name:" prefix.
+		name := ""
+		if t.typ == tokIdent {
+			t2, err := p.peekN(1)
+			if err != nil {
+				return err
+			}
+			if t2.typ == tokColon {
+				_, _ = p.consume() // ident
+				_, _ = p.consume() // colon
+				name = t.text
+			}
+		}
+		if name == "" {
+			anon++
+			name = fmt.Sprintf("c%d", anon)
+		}
+
+		expr, lhsConst, err := p.parseExprAndConst(b)
+		if err != nil {
+			return err
+		}
+
+		opTok, err := p.consume()
+		if err != nil {
+			return err
+		}
+		var ctype ConstraintType
+		switch opTok.typ {
+		case tokLE:
+			ctype = LTE
+		case tokGE:
+			ctype = GTE
+		case tokEQ:
+			ctype = EQ
+		default:
+			return errAt(opTok.line, opTok.col, "expected '<=', '>=', or '=' in constraint %q", name)
+		}
+
+		rhs, err := p.parseSignedNumber()
+		if err != nil {
+			return err
+		}
+
+		// Range constraints ("3 <= expr <= 10") are not modeled by grove
+		// today — surface a clear diagnostic rather than silently drop
+		// the second half.
+		if tNext, err := p.peek(); err == nil {
+			if tNext.typ == tokLE || tNext.typ == tokGE {
+				return errAt(tNext.line, tNext.col, "range constraints are not supported in constraint %q", name)
+			}
+		}
+
+		if _, exists := b.prob.consNames[name]; exists {
+			return errAt(opTok.line, opTok.col, "duplicate constraint name %q", name)
+		}
+		b.prob.AddConstraint(name, expr, ctype, rhs-lhsConst)
+	}
+}
+
+func (b *builder) parseBounds(sec section) error {
+	for _, line := range sec.body {
+		if strings.TrimSpace(line.text) == "" {
+			continue
+		}
+		if err := b.parseBoundLine(line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseBoundLine accepts any of the CPLEX LP bound statement shapes:
+//
+//	x free                           -> (-∞, +∞)
+//	x <= u                           -> upper bound u
+//	x >= l   (or  x > l)             -> lower bound l
+//	x = v                            -> x fixed at v
+//	l <= x                           -> lower bound l
+//	l <= x <= u                      -> two-sided
+//	-inf <= x <= +inf                -> free (via infinity keywords)
+//
+// The reverse form "u >= x" is also accepted and treated as "x <= u".
+func (b *builder) parseBoundLine(line srcLine) error {
+	p := &parser{tok: newTokenizer([]srcLine{line})}
+
+	t, err := p.peek()
+	if err != nil {
+		return err
+	}
+	switch t.typ {
+	case tokIdent:
+		_, _ = p.consume()
+		v := b.getVar(t.text)
+
+		t2, err := p.consume()
+		if err != nil {
+			return err
+		}
+		if t2.typ == tokIdent && strings.EqualFold(t2.text, "free") {
+			v.low = math.Inf(-1)
+			v.high = math.Inf(1)
+			return p.expectEOF()
+		}
+		switch t2.typ {
+		case tokLE:
+			num, err := p.parseSignedNumber()
+			if err != nil {
+				return err
+			}
+			v.high = num
+		case tokGE:
+			num, err := p.parseSignedNumber()
+			if err != nil {
+				return err
+			}
+			v.low = num
+		case tokEQ:
+			num, err := p.parseSignedNumber()
+			if err != nil {
+				return err
+			}
+			v.low = num
+			v.high = num
+		default:
+			return errAt(t2.line, t2.col, "expected '<=', '>=', '=', or 'free' after variable %q", t.text)
+		}
+		return p.expectEOF()
+
+	case tokNumber, tokPlus, tokMinus:
+		lo, err := p.parseSignedNumber()
+		if err != nil {
+			return err
+		}
+		opTok, err := p.consume()
+		if err != nil {
+			return err
+		}
+		var flipped bool
+		switch opTok.typ {
+		case tokLE:
+			flipped = false
+		case tokGE:
+			flipped = true
+		default:
+			return errAt(opTok.line, opTok.col, "expected '<=' or '>=' after bound value")
+		}
+		idTok, err := p.consume()
+		if err != nil {
+			return err
+		}
+		if idTok.typ != tokIdent {
+			return errAt(idTok.line, idTok.col, "expected variable name")
+		}
+		v := b.getVar(idTok.text)
+
+		t3, err := p.peek()
+		if err != nil {
+			return err
+		}
+		if t3.typ == tokLE || t3.typ == tokGE {
+			_, _ = p.consume()
+			hi, err := p.parseSignedNumber()
+			if err != nil {
+				return err
+			}
+			if flipped {
+				v.high = lo
+				v.low = hi
+			} else {
+				v.low = lo
+				v.high = hi
+			}
+		} else {
+			if flipped {
+				v.high = lo
+			} else {
+				v.low = lo
+			}
+		}
+		return p.expectEOF()
+	}
+	return errAt(t.line, t.col, "unexpected token %q in bounds", t.text)
+}
+
+func (b *builder) parseVarList(sec section, kind VarKind) error {
+	p := &parser{tok: newTokenizer(sec.body)}
+	for {
+		t, err := p.consume()
+		if err != nil {
+			return err
+		}
+		if t.typ == tokEOF {
+			return nil
+		}
+		if t.typ != tokIdent {
+			return errAt(t.line, t.col, "expected variable name, got %q", t.text)
+		}
+		v := b.getVar(t.text)
+		v.kind = kind
+		// The LP convention: Binary variables are pinned to [0, 1]
+		// regardless of any earlier Bounds row. (Mirrors NewVar.)
+		if kind == Binary {
+			v.low, v.high = 0, 1
+		}
+	}
+}
+
+func hasContent(body []srcLine) bool {
+	for _, l := range body {
+		if strings.TrimSpace(l.text) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// parseLP is the top-level routing function. It walks the section list,
+// picks up the objective sense, then hands each section to the
+// appropriate parser. The order mirrors the LP file format: objective,
+// then Subject To, then Bounds, then General/Binary, then End.
+func parseLP(src string) (*Problem, error) {
+	sections := splitSections(src)
+
+	var sense Sense
+	var senseFound bool
+	var objSection section
+	var stSection section
+	var boundsSection section
+	var generalSections []section
+	var binarySections []section
+
+	for _, sec := range sections {
+		switch sec.kind {
+		case secNone:
+			// Accept only empty preambles / trailing regions. A
+			// non-empty sectionless block is a structural error.
+			if hasContent(sec.body) && senseFound {
+				continue // tolerate trailing junk after End
+			}
+			if hasContent(sec.body) {
+				l := sec.body[0]
+				return nil, errAt(l.no, 1, "content before Minimize/Maximize header")
+			}
+		case secMin:
+			if senseFound {
+				return nil, errAt(sec.header, 0, "duplicate objective section")
+			}
+			sense = Minimize
+			senseFound = true
+			objSection = sec
+		case secMax:
+			if senseFound {
+				return nil, errAt(sec.header, 0, "duplicate objective section")
+			}
+			sense = Maximize
+			senseFound = true
+			objSection = sec
+		case secST:
+			stSection = sec
+		case secBounds:
+			boundsSection = sec
+		case secGeneral:
+			generalSections = append(generalSections, sec)
+		case secBinary:
+			binarySections = append(binarySections, sec)
+		case secSOS:
+			// Silently skip — grove does not model SOS sets (yet).
+		case secEnd:
+			// Stop looking at further content; LP format sanctions
+			// whatever appears after End.
+			goto done
+		}
+	}
+done:
+
+	if !senseFound {
+		return nil, &parseError{Msg: "missing Minimize/Maximize section"}
+	}
+
+	prob := NewProblem("", sense)
+	b := &builder{prob: prob, vars: map[string]*Var{}}
+
+	if err := b.parseObjective(objSection); err != nil {
+		return nil, err
+	}
+	if stSection.kind == secST {
+		if err := b.parseConstraints(stSection); err != nil {
+			return nil, err
+		}
+	}
+	if boundsSection.kind == secBounds {
+		if err := b.parseBounds(boundsSection); err != nil {
+			return nil, err
+		}
+	}
+	for _, g := range generalSections {
+		if err := b.parseVarList(g, Integer); err != nil {
+			return nil, err
+		}
+	}
+	for _, bn := range binarySections {
+		if err := b.parseVarList(bn, Binary); err != nil {
+			return nil, err
+		}
+	}
+	return prob, nil
+}

--- a/reader.go
+++ b/reader.go
@@ -51,14 +51,28 @@ func ReadLP(r io.Reader) (*Problem, error) {
 	return parseLP(string(data))
 }
 
-// parseError carries a 1-based line and column so the caller can point
-// the user at the offending spot.
-type parseError struct {
+// ParseError is the error type returned by [ReadLP] for malformed
+// input. Line and Col are 1-based; Col is 0 when a position inside a
+// line isn't meaningful (for example, when the error is about a missing
+// section header). Msg is the bare diagnostic — the fully formatted
+// form produced by Error also carries the "grove: LP parse error …"
+// prefix.
+//
+// Callers may type-assert on *ParseError (or use [errors.As]) to pull
+// the structured line/column out, e.g. to underline the offending spot
+// in an editor:
+//
+//	var pe *grove.ParseError
+//	if errors.As(err, &pe) {
+//	    highlight(path, pe.Line, pe.Col)
+//	}
+type ParseError struct {
 	Line, Col int
 	Msg       string
 }
 
-func (e *parseError) Error() string {
+// Error formats the parse error with its line (and column, when known).
+func (e *ParseError) Error() string {
 	switch {
 	case e.Col > 0 && e.Line > 0:
 		return fmt.Sprintf("grove: LP parse error at line %d, column %d: %s", e.Line, e.Col, e.Msg)
@@ -69,8 +83,8 @@ func (e *parseError) Error() string {
 	}
 }
 
-func errAt(line, col int, format string, args ...any) *parseError {
-	return &parseError{Line: line, Col: col, Msg: fmt.Sprintf(format, args...)}
+func errAt(line, col int, format string, args ...any) *ParseError {
+	return &ParseError{Line: line, Col: col, Msg: fmt.Sprintf(format, args...)}
 }
 
 // srcLine is an input line with its original 1-based line number.
@@ -908,7 +922,7 @@ func parseLP(src string) (*Problem, error) {
 done:
 
 	if !senseFound {
-		return nil, &parseError{Msg: "missing Minimize/Maximize section"}
+		return nil, &ParseError{Msg: "missing Minimize/Maximize section"}
 	}
 
 	prob := NewProblem("", sense)

--- a/reader.go
+++ b/reader.go
@@ -650,17 +650,37 @@ func (b *builder) parseConstraints(sec section) error {
 			return errAt(opTok.line, opTok.col, "expected '<=', '>=', or '=' in constraint %q", name)
 		}
 
+		// Range constraints ("low <= expr <= high" or the mirror form
+		// "high >= expr >= low") are not modeled by grove today. Detect
+		// them up front — otherwise a constant LHS lands us in
+		// parseSignedNumber below, which would report a misleading
+		// "expected number" error against the first variable of the
+		// middle expression.
+		if len(expr) == 0 && (ctype == LTE || ctype == GTE) {
+			midExpr, _, merr := p.parseExprAndConst(b)
+			if merr != nil {
+				return errAt(opTok.line, opTok.col,
+					"constraint %q: left-hand side must include at least one variable", name)
+			}
+			if tail, _ := p.peek(); len(midExpr) > 0 && (tail.typ == tokLE || tail.typ == tokGE) {
+				return errAt(opTok.line, opTok.col,
+					"range constraints (low <= expr <= high) are not supported in constraint %q", name)
+			}
+			return errAt(opTok.line, opTok.col,
+				"constraint %q: left-hand side must include at least one variable", name)
+		}
+
 		rhs, err := p.parseSignedNumber()
 		if err != nil {
 			return err
 		}
 
-		// Range constraints ("3 <= expr <= 10") are not modeled by grove
-		// today — surface a clear diagnostic rather than silently drop
-		// the second half.
+		// Also catch the unusual mirror form "expr <= rhs <= higher"
+		// where the LHS does carry variables.
 		if tNext, err := p.peek(); err == nil {
 			if tNext.typ == tokLE || tNext.typ == tokGE {
-				return errAt(tNext.line, tNext.col, "range constraints are not supported in constraint %q", name)
+				return errAt(tNext.line, tNext.col,
+					"range constraints (low <= expr <= high) are not supported in constraint %q", name)
 			}
 		}
 

--- a/reader_test.go
+++ b/reader_test.go
@@ -490,6 +490,59 @@ func TestReadLPMissingSenseHeader(t *testing.T) {
 	}
 }
 
+func TestReadLPRangeConstraintDiagnostic(t *testing.T) {
+	// Classic range form: constant LHS, variables in the middle.
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			"low <= expr <= high",
+			"Minimize\n obj: x + y\nSubject To\n c1: 3 <= x + y <= 10\nEnd\n",
+		},
+		{
+			"high >= expr >= low",
+			"Minimize\n obj: x + y\nSubject To\n c1: 10 >= x + y >= 3\nEnd\n",
+		},
+		{
+			"expr <= rhs <= higher (mirror form)",
+			"Minimize\n obj: x + y\nSubject To\n c1: x + y <= 10 <= 20\nEnd\n",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ReadLP(strings.NewReader(c.src))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "range constraints") {
+				t.Errorf("error should mention range constraints, got: %v", err)
+			}
+			pe, ok := err.(*parseError)
+			if !ok || pe.Line == 0 {
+				t.Errorf("error should carry a line number: %v", err)
+			}
+		})
+	}
+}
+
+func TestReadLPConstantOnlyLHSDiagnostic(t *testing.T) {
+	// Not a range — just a malformed constraint with no variables on
+	// the left. The diagnostic should point at that, not at range
+	// constraints.
+	src := "Minimize\n obj: x\nSubject To\n c1: 3 <= 5\nEnd\n"
+	_, err := ReadLP(strings.NewReader(src))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "at least one variable") {
+		t.Errorf("diagnostic should call out missing variable; got: %v", err)
+	}
+	if strings.Contains(err.Error(), "range constraints") {
+		t.Errorf("should not mislabel as range constraint: %v", err)
+	}
+}
+
 func TestReadLPDuplicateConstraintName(t *testing.T) {
 	src := `Minimize
  obj: x

--- a/reader_test.go
+++ b/reader_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/iotest"
 )
 
 // ── Comparison helpers ────────────────────────────────────────────────
@@ -578,4 +579,43 @@ func TestReadLPTestdataFile(t *testing.T) {
 	}
 	// Round-trip.
 	problemsEquivalent(t, p, roundTrip(t, p))
+}
+
+// TestReadLPStreamingOneByteReader pushes a small model through
+// iotest.OneByteReader so the bufio.Scanner under ReadLP has to
+// reassemble every single line a byte at a time. Exercises the
+// line-by-line streaming path without depending on file sizes.
+func TestReadLPStreamingOneByteReader(t *testing.T) {
+	src := "Minimize\n" +
+		" obj: 2 x + y\n" +
+		"Subject To\n" +
+		" c1: x + y >= 3\n" +
+		"Bounds\n" +
+		" 0 <= x <= 5\n" +
+		" y >= 0\n" +
+		"General\n" +
+		" x\n" +
+		"End\n"
+
+	p, err := ReadLP(iotest.OneByteReader(strings.NewReader(src)))
+	if err != nil {
+		t.Fatalf("ReadLP (one-byte reader): %v", err)
+	}
+	if p.Sense() != Minimize {
+		t.Errorf("sense = %v, want Minimize", p.Sense())
+	}
+	vs := indexVarsByName(p)
+	x, ok := vs["x"]
+	if !ok {
+		t.Fatalf("missing var x")
+	}
+	if x.Kind() != Integer {
+		t.Errorf("x kind = %v, want Integer", x.Kind())
+	}
+	if !boundsEqual(x.Low(), 0) || !boundsEqual(x.High(), 5) {
+		t.Errorf("x bounds = [%g,%g], want [0,5]", x.Low(), x.High())
+	}
+	if got := len(p.Constraints()); got != 1 {
+		t.Fatalf("constraint count = %d, want 1", got)
+	}
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -565,7 +565,11 @@ func TestReadLPTestdataFile(t *testing.T) {
 	path := filepath.Join("testdata", "transport.lp")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		t.Skipf("testdata file missing: %v", err)
+		// transport.lp is checked into the repo, so a read failure
+		// here indicates a packaging/CI problem (wrong cwd, missing
+		// testdata tree, etc.) and should fail loudly rather than
+		// silently skip.
+		t.Fatalf("read %s: %v", path, err)
 	}
 	p, err := ReadLP(bytes.NewReader(data))
 	if err != nil {

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,527 @@
+package grove
+
+import (
+	"bytes"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── Comparison helpers ────────────────────────────────────────────────
+
+// problemsEquivalent is a structural equality check for two *Problem
+// values. It does not require declaration order to match — only that
+// every named element is present on both sides with identical data.
+// Used to verify round-trips through WriteLP → ReadLP.
+func problemsEquivalent(t *testing.T, want, got *Problem) {
+	t.Helper()
+	if want.Sense() != got.Sense() {
+		t.Errorf("sense: want %v, got %v", want.Sense(), got.Sense())
+	}
+	if math.Abs(want.ObjectiveConstant()-got.ObjectiveConstant()) > 1e-12 {
+		t.Errorf("objective constant: want %g, got %g",
+			want.ObjectiveConstant(), got.ObjectiveConstant())
+	}
+
+	wantVars := indexVarsByName(want)
+	gotVars := indexVarsByName(got)
+	if len(wantVars) != len(gotVars) {
+		t.Errorf("var count: want %d, got %d", len(wantVars), len(gotVars))
+	}
+	for name, wv := range wantVars {
+		gv, ok := gotVars[name]
+		if !ok {
+			t.Errorf("missing var %q after round-trip", name)
+			continue
+		}
+		if wv.Kind() != gv.Kind() {
+			t.Errorf("var %q kind: want %v, got %v", name, wv.Kind(), gv.Kind())
+		}
+		if !boundsEqual(wv.Low(), gv.Low()) || !boundsEqual(wv.High(), gv.High()) {
+			t.Errorf("var %q bounds: want [%g,%g], got [%g,%g]",
+				name, wv.Low(), wv.High(), gv.Low(), gv.High())
+		}
+	}
+
+	// Objective coefficients keyed by variable name.
+	wantObj := objByName(want)
+	gotObj := objByName(got)
+	if len(wantObj) != len(gotObj) {
+		t.Errorf("objective term count: want %d, got %d", len(wantObj), len(gotObj))
+	}
+	for name, c := range wantObj {
+		if math.Abs(c-gotObj[name]) > 1e-12 {
+			t.Errorf("objective coef on %q: want %g, got %g", name, c, gotObj[name])
+		}
+	}
+
+	// Constraints keyed by name.
+	wantCons := indexConstraintsByName(want)
+	gotCons := indexConstraintsByName(got)
+	if len(wantCons) != len(gotCons) {
+		t.Errorf("constraint count: want %d, got %d", len(wantCons), len(gotCons))
+	}
+	for name, wc := range wantCons {
+		gc, ok := gotCons[name]
+		if !ok {
+			t.Errorf("missing constraint %q after round-trip", name)
+			continue
+		}
+		if wc.Type() != gc.Type() {
+			t.Errorf("constraint %q type: want %v, got %v", name, wc.Type(), gc.Type())
+		}
+		if math.Abs(wc.RHS()-gc.RHS()) > 1e-12 {
+			t.Errorf("constraint %q rhs: want %g, got %g", name, wc.RHS(), gc.RHS())
+		}
+		wExpr := exprByName(wc.Expr())
+		gExpr := exprByName(gc.Expr())
+		if len(wExpr) != len(gExpr) {
+			t.Errorf("constraint %q term count: want %d, got %d",
+				name, len(wExpr), len(gExpr))
+		}
+		for vn, c := range wExpr {
+			if math.Abs(c-gExpr[vn]) > 1e-12 {
+				t.Errorf("constraint %q coef on %q: want %g, got %g",
+					name, vn, c, gExpr[vn])
+			}
+		}
+	}
+}
+
+func indexVarsByName(p *Problem) map[string]*Var {
+	m := make(map[string]*Var, len(p.Vars()))
+	for _, v := range p.Vars() {
+		m[v.Name()] = v
+	}
+	return m
+}
+
+func indexConstraintsByName(p *Problem) map[string]*Constraint {
+	m := make(map[string]*Constraint, len(p.Constraints()))
+	for _, c := range p.Constraints() {
+		m[c.Name()] = c
+	}
+	return m
+}
+
+func objByName(p *Problem) map[string]float64 {
+	m := make(map[string]float64, len(p.Objective()))
+	for v, c := range p.Objective() {
+		m[v.Name()] = c
+	}
+	return m
+}
+
+func exprByName(e Expr) map[string]float64 {
+	m := make(map[string]float64, len(e))
+	for v, c := range e {
+		m[v.Name()] = c
+	}
+	return m
+}
+
+func boundsEqual(a, b float64) bool {
+	if math.IsInf(a, 1) && math.IsInf(b, 1) {
+		return true
+	}
+	if math.IsInf(a, -1) && math.IsInf(b, -1) {
+		return true
+	}
+	return math.Abs(a-b) < 1e-12
+}
+
+// roundTrip writes p to LP, reads it back, and returns the new *Problem.
+func roundTrip(t *testing.T, p *Problem) *Problem {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := p.WriteLP(&buf); err != nil {
+		t.Fatalf("WriteLP: %v", err)
+	}
+	got, err := ReadLP(&buf)
+	if err != nil {
+		t.Fatalf("ReadLP: %v\nLP:\n%s", err, buf.String())
+	}
+	return got
+}
+
+// ── Example models (structurally equal to the examples/ programs) ─────
+
+// buildSchedulingExample mirrors examples/scheduling/main.go.
+func buildSchedulingExample() *Problem {
+	demand := []float64{40, 32, 35, 38, 45, 28, 25}
+	days := []string{"mon", "tue", "wed", "thu", "fri", "sat", "sun"}
+	const (
+		fullHours = 8.0
+		partHours = 4.0
+		fullCost  = 280.0
+		partCost  = 160.0
+	)
+
+	p := NewProblem("nurse_schedule", Minimize)
+
+	full := make([]*Var, len(days))
+	part := make([]*Var, len(days))
+	for i, d := range days {
+		full[i] = p.NewVar("full_"+d, Continuous, Bounds(0, Inf))
+		part[i] = p.NewVar("part_"+d, Continuous, Bounds(0, Inf))
+	}
+
+	obj := Expr{}
+	for i := range days {
+		obj[full[i]] = fullCost
+		obj[part[i]] = partCost
+	}
+	p.SetObjective(obj)
+
+	for i, d := range days {
+		p.AddConstraint("cover_"+d,
+			Expr{full[i]: fullHours, part[i]: partHours},
+			GTE, demand[i])
+	}
+	p.AddConstraint("part_cap_sat", Expr{part[5]: 1}, LTE, 4)
+	p.AddConstraint("part_cap_sun", Expr{part[6]: 1}, LTE, 4)
+	return p
+}
+
+// buildDietExample mirrors examples/diet/main.go.
+func buildDietExample() *Problem {
+	type food struct {
+		name                          string
+		cost, cal, pro, fat, carb, na float64
+	}
+	foods := []food{
+		{"oats", 3.00, 389, 17, 7, 66, 2},
+		{"chicken_breast", 10.00, 165, 31, 4, 0, 74},
+		{"broccoli", 4.00, 34, 3, 0, 7, 33},
+		{"olive_oil", 12.00, 884, 0, 100, 0, 2},
+		{"brown_rice", 2.50, 370, 8, 3, 77, 7},
+		{"black_beans", 3.50, 132, 9, 1, 24, 2},
+		{"spinach", 5.00, 23, 3, 0, 4, 79},
+		{"banana", 1.50, 89, 1, 0, 23, 1},
+		{"egg", 5.50, 155, 13, 11, 1, 124},
+		{"yogurt_greek", 7.00, 59, 10, 0, 4, 36},
+	}
+	p := NewProblem("diet", Minimize)
+	x := make([]*Var, len(foods))
+	for i, f := range foods {
+		x[i] = p.NewVar(f.name, Continuous, Bounds(0, 20))
+	}
+	obj := Expr{}
+	for i, f := range foods {
+		obj[x[i]] = f.cost / 10
+	}
+	p.SetObjective(obj)
+
+	cal, pro, fat, carb, na := Expr{}, Expr{}, Expr{}, Expr{}, Expr{}
+	for i, f := range foods {
+		cal[x[i]] = f.cal
+		pro[x[i]] = f.pro
+		fat[x[i]] = f.fat
+		carb[x[i]] = f.carb
+		na[x[i]] = f.na
+	}
+	p.AddConstraint("calories_min", cal, GTE, 2000)
+	p.AddConstraint("calories_max", cal, LTE, 2400)
+	p.AddConstraint("protein_min", pro, GTE, 100)
+	p.AddConstraint("fat_max", fat, LTE, 80)
+	p.AddConstraint("carbs_min", carb, GTE, 250)
+	p.AddConstraint("sodium_max", na, LTE, 2300)
+	return p
+}
+
+// buildAllocationExample mirrors examples/allocation/main.go.
+func buildAllocationExample() *Problem {
+	type workload struct {
+		name                string
+		cpu, ram, disk, val float64
+	}
+	wls := []workload{
+		{"checkout-api", 4, 16, 80, 90},
+		{"recommender", 8, 32, 200, 70},
+		{"batch-etl", 16, 64, 500, 50},
+		{"image-resize", 2, 8, 40, 30},
+		{"search-index", 6, 24, 150, 60},
+		{"ml-train", 32, 128, 1000, 200},
+		{"audit-log", 1, 4, 200, 10},
+		{"webhook-fan", 2, 8, 20, 25},
+	}
+	p := NewProblem("vm_allocation", Maximize)
+	frac := make([]*Var, len(wls))
+	for i, w := range wls {
+		frac[i] = p.NewVar(w.name, Continuous, Bounds(0, 1))
+	}
+	obj := Expr{}
+	for i, w := range wls {
+		obj[frac[i]] = w.val
+	}
+	p.SetObjective(obj)
+	cpu, ram, disk := Expr{}, Expr{}, Expr{}
+	for i, w := range wls {
+		cpu[frac[i]] = w.cpu
+		ram[frac[i]] = w.ram
+		disk[frac[i]] = w.disk
+	}
+	p.AddConstraint("cpu", cpu, LTE, 64)
+	p.AddConstraint("ram", ram, LTE, 256)
+	p.AddConstraint("disk", disk, LTE, 4000)
+	return p
+}
+
+// ── Round-trip tests ──────────────────────────────────────────────────
+
+func TestReadLPRoundTripExamples(t *testing.T) {
+	// WriteLP is lossy for two things we don't try to reverse here:
+	//   1. `sanitize` rewrites non-identifier characters (e.g. dashes
+	//      in allocation's "batch-etl") to underscores.
+	//   2. Zero-coefficient terms in an expression are dropped.
+	// So the round-trip contract is expressed as text fixed-point:
+	// WriteLP(p) == WriteLP(ReadLP(WriteLP(p))). Every example keeps
+	// all variables in the objective, so declaration order is stable
+	// and the writer's byte output is deterministic.
+	examples := []struct {
+		name  string
+		build func() *Problem
+	}{
+		{"scheduling", buildSchedulingExample},
+		{"diet", buildDietExample},
+		{"allocation", buildAllocationExample},
+	}
+	for _, ex := range examples {
+		t.Run(ex.name, func(t *testing.T) {
+			p := ex.build()
+			var first bytes.Buffer
+			if err := p.WriteLP(&first); err != nil {
+				t.Fatalf("WriteLP: %v", err)
+			}
+			got, err := ReadLP(bytes.NewReader(first.Bytes()))
+			if err != nil {
+				t.Fatalf("ReadLP: %v\nLP:\n%s", err, first.String())
+			}
+			var second bytes.Buffer
+			if err := got.WriteLP(&second); err != nil {
+				t.Fatalf("WriteLP (2nd): %v", err)
+			}
+			if first.String() != second.String() {
+				t.Errorf("WriteLP output differs after round-trip.\n--- first ---\n%s\n--- second ---\n%s",
+					first.String(), second.String())
+			}
+		})
+	}
+}
+
+func TestReadLPRoundTripIntegerAndBinary(t *testing.T) {
+	// Cover General / Binary sections and mixed bounds in one shot.
+	p := NewProblem("mip", Maximize)
+	x := p.NewVar("x", Continuous, Bounds(0, 10))
+	y := p.NewVar("y", Integer, Bounds(0, Inf))
+	z := p.NewVar("z", Binary)
+	free := p.NewVar("free_var", Continuous, Bounds(-Inf, Inf))
+	p.SetObjective(Expr{x: 1, y: 2, z: -3, free: 0.5})
+	p.SetObjectiveConstant(7.5)
+	p.AddConstraint("c1", Expr{x: 1, y: 1}, LTE, 5)
+	p.AddConstraint("c2", Expr{x: 2, z: 1}, GTE, 1)
+	p.AddConstraint("c3", Expr{free: 1, x: -1}, EQ, 0)
+
+	got := roundTrip(t, p)
+	problemsEquivalent(t, p, got)
+}
+
+// ── Real-world LP (MIPLIB-style mixed integer knapsack) ───────────────
+
+// The file is a compact mixed-integer LP that exercises every section
+// and several syntactic tolerances the wild throws at parsers:
+//   - lowercase section keywords
+//   - the "s.t." abbreviation
+//   - continuation over multiple lines within a single expression
+//   - implicit "1" coefficients on binary vars
+//   - mixed bound forms (one-sided, two-sided, "free", "= fixed")
+//   - inline backslash comments
+//   - blank lines between and within sections
+const miplibStyleLP = `\ Small MIP: pack items under weight + volume caps to maximise value.
+\ Adapted from a MIPLIB-style knapsack; every section exercised.
+
+Maximize
+ profit: 10 x1 + 20 x2 + 15 x3
+       + 25 x4 + 8 x5 + 30 x6
+       - 5 slack + 100
+
+Subject To
+ weight:   5 x1 + 7 x2 + 4 x3 + 9 x4 + 3 x5 + 11 x6 <= 40
+ volume:   3 x1 + 2 x2 + 6 x3 + 4 x4 + 2 x5 + 5 x6  <= 18
+ pairing:  x2 - x4 = 0
+ must_one: x1 + x3 + x6 >= 1
+ bal:      slack - 2 x5 = 0
+
+\ --- bounds section with varied shapes ---
+Bounds
+ 0 <= slack <= 15
+ x5 free
+ x1 <= 1
+
+Binary
+ x1 x2 x3
+ x4
+
+Generals
+ x5 x6
+
+End
+`
+
+func TestReadLPRealWorldStyle(t *testing.T) {
+	p, err := ReadLP(strings.NewReader(miplibStyleLP))
+	if err != nil {
+		t.Fatalf("ReadLP: %v", err)
+	}
+	if p.Sense() != Maximize {
+		t.Errorf("sense = %v, want Maximize", p.Sense())
+	}
+	if math.Abs(p.ObjectiveConstant()-100) > 1e-12 {
+		t.Errorf("obj const = %g, want 100", p.ObjectiveConstant())
+	}
+	// Check a few variable shapes.
+	names := indexVarsByName(p)
+	for _, n := range []string{"x1", "x2", "x3", "x4", "x5", "x6", "slack"} {
+		if names[n] == nil {
+			t.Fatalf("missing var %q", n)
+		}
+	}
+	for _, n := range []string{"x1", "x2", "x3", "x4"} {
+		if names[n].Kind() != Binary {
+			t.Errorf("var %q should be Binary, got %v", n, names[n].Kind())
+		}
+	}
+	for _, n := range []string{"x5", "x6"} {
+		if names[n].Kind() != Integer {
+			t.Errorf("var %q should be Integer, got %v", n, names[n].Kind())
+		}
+	}
+	if lo, hi := names["slack"].Low(), names["slack"].High(); lo != 0 || hi != 15 {
+		t.Errorf("slack bounds = [%g,%g], want [0,15]", lo, hi)
+	}
+	if !math.IsInf(names["x5"].Low(), -1) || !math.IsInf(names["x5"].High(), 1) {
+		// x5 declared free, then listed as Integer; Integer keeps existing bounds.
+		t.Errorf("x5 free bounds lost: [%g,%g]", names["x5"].Low(), names["x5"].High())
+	}
+	// Round-trip preserves structure.
+	got := roundTrip(t, p)
+	problemsEquivalent(t, p, got)
+}
+
+// ── Comments and blank lines anywhere ────────────────────────────────
+
+func TestReadLPTolerantOfCommentsAndBlanks(t *testing.T) {
+	src := `\ leading comment
+\ another
+
+Minimize \ inline comment on header is stripped pre-match
+ obj: x + y   \ trailing comment
+
+\ comment between sections
+
+Subject To
+
+ c1: x + y <= 10   \ first constraint
+\ dense comment
+ c2: x - y  =  0
+
+
+Bounds
+
+ 0 <= x <= 5
+ \ a floating comment
+ 0 <= y <= 5
+
+End
+`
+	p, err := ReadLP(strings.NewReader(src))
+	if err != nil {
+		t.Fatalf("ReadLP: %v", err)
+	}
+	if n := len(p.Vars()); n != 2 {
+		t.Errorf("vars = %d, want 2", n)
+	}
+	if n := len(p.Constraints()); n != 2 {
+		t.Errorf("constraints = %d, want 2", n)
+	}
+}
+
+// ── Error reporting carries line and column ───────────────────────────
+
+func TestReadLPErrorsIncludeLineAndColumn(t *testing.T) {
+	// Deliberately mangled expression: two variables with no operator
+	// between them. The second identifier lives on line 5, and our
+	// tokenizer will complain when it tries to consume the next term.
+	src := `Minimize
+ obj: 2 x 3 y
+Subject To
+ c1: x >= 0
+End
+`
+	_, err := ReadLP(strings.NewReader(src))
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	pe, ok := err.(*parseError)
+	if !ok {
+		t.Fatalf("error is not *parseError: %T (%v)", err, err)
+	}
+	if pe.Line == 0 {
+		t.Errorf("parse error missing line number: %v", err)
+	}
+	if pe.Col == 0 {
+		t.Errorf("parse error missing column number: %v", err)
+	}
+	if !strings.Contains(err.Error(), "line") {
+		t.Errorf("formatted error should contain 'line': %q", err.Error())
+	}
+}
+
+func TestReadLPMissingSenseHeader(t *testing.T) {
+	src := "Subject To\n c: x >= 0\nEnd\n"
+	_, err := ReadLP(strings.NewReader(src))
+	if err == nil {
+		t.Fatal("expected error for missing sense header")
+	}
+	if !strings.Contains(err.Error(), "Minimize") {
+		t.Errorf("error should mention Minimize/Maximize: %v", err)
+	}
+}
+
+func TestReadLPDuplicateConstraintName(t *testing.T) {
+	src := `Minimize
+ obj: x
+Subject To
+ c1: x <= 5
+ c1: x >= 1
+End
+`
+	_, err := ReadLP(strings.NewReader(src))
+	if err == nil {
+		t.Fatal("expected duplicate-name error")
+	}
+}
+
+// ── Testdata file round-trip ──────────────────────────────────────────
+
+func TestReadLPTestdataFile(t *testing.T) {
+	path := filepath.Join("testdata", "transport.lp")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("testdata file missing: %v", err)
+	}
+	p, err := ReadLP(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ReadLP %s: %v", path, err)
+	}
+	if p.Sense() != Minimize {
+		t.Errorf("sense = %v, want Minimize", p.Sense())
+	}
+	if _, err := p.Solve(); err != nil {
+		t.Fatalf("Solve of parsed problem: %v", err)
+	}
+	// Round-trip.
+	problemsEquivalent(t, p, roundTrip(t, p))
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -2,6 +2,7 @@ package grove
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"os"
 	"path/filepath"
@@ -464,9 +465,9 @@ End
 	if err == nil {
 		t.Fatal("expected parse error")
 	}
-	pe, ok := err.(*parseError)
-	if !ok {
-		t.Fatalf("error is not *parseError: %T (%v)", err, err)
+	var pe *ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("error is not *ParseError: %T (%v)", err, err)
 	}
 	if pe.Line == 0 {
 		t.Errorf("parse error missing line number: %v", err)
@@ -518,8 +519,8 @@ func TestReadLPRangeConstraintDiagnostic(t *testing.T) {
 			if !strings.Contains(err.Error(), "range constraints") {
 				t.Errorf("error should mention range constraints, got: %v", err)
 			}
-			pe, ok := err.(*parseError)
-			if !ok || pe.Line == 0 {
+			var pe *ParseError
+			if !errors.As(err, &pe) || pe.Line == 0 {
 				t.Errorf("error should carry a line number: %v", err)
 			}
 		})

--- a/testdata/transport.lp
+++ b/testdata/transport.lp
@@ -1,0 +1,25 @@
+\ Classical transportation LP: ship units from two plants to three
+\ warehouses at minimum total cost, subject to supply caps and demand
+\ floors. Small enough to eyeball, large enough to exercise multiple
+\ sections and a variety of bound forms.
+
+Minimize
+ cost: 4 x11 + 6 x12 + 9 x13
+     + 5 x21 + 3 x22 + 8 x23
+
+Subject To
+ supply_1: x11 + x12 + x13 <= 100
+ supply_2: x21 + x22 + x23 <= 150
+ demand_1: x11 + x21 >= 80
+ demand_2: x12 + x22 >= 70
+ demand_3: x13 + x23 >= 100
+
+Bounds
+ 0 <= x11 <= 100
+ 0 <= x12 <= 100
+ 0 <= x13 <= 100
+ 0 <= x21 <= 150
+ 0 <= x22 <= 150
+ 0 <= x23 <= 150
+
+End


### PR DESCRIPTION
Closes #1

Add ReadLP(io.Reader) (*Problem, error) as the inverse of WriteLP so models can flow back into grove from disk or from MIPLIB archives. The reader is a small section-based parser (Minimize/Maximize, Subject To, Bounds, General, Binary, End) with case-insensitive keywords, the usual abbreviated forms (Min/Max, s.t./st/such that, Bound, Gen/Integer, Bin/Binaries), multi-line expressions, backslash comments, and blank-line tolerance anywhere. Undeclared variables default to [0, +Inf] continuous, matching the CPLEX default. Parse errors are *parseError values that carry a 1-based line and column.

Round-trip coverage: each examples/ model (scheduling, diet, allocation) as a WriteLP→ReadLP→WriteLP byte fixed-point; a mixed integer/binary/free-variable model as a structural round-trip; a MIPLIB-style LP embedded in the test and a transportation LP on disk in testdata/transport.lp exercising every tolerated syntactic variant.