### PR TITLE
v0.2: implement presolve pass 

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,7 +47,7 @@ Target: **Q3.** Backwards-compatible additions only. Epic: [#24](https://github.
 - Solution warm-starting: `Solver` interface gains `SolveWith(prob,
   startingBasis)` for re-solving after small model edits.
   ([#4](https://github.com/JakenHerman/grove/issues/4))
-- Presolve pass that drops empty rows/columns and detects fixed
+- [x] Presolve pass that drops empty rows/columns and detects fixed
   variables before the simplex starts.
   ([#5](https://github.com/JakenHerman/grove/issues/5))
 - Constraint validation upgrades: detect duplicates, empty rows,

--- a/docs/guide/api-reference.html
+++ b/docs/guide/api-reference.html
@@ -188,6 +188,10 @@
           <span class="sig">MaxIterations int</span>
           <p>Hard pivot cap. <code>0</code> (the default) means &ldquo;use the solver default&rdquo; — effectively unbounded.</p>
         </div>
+        <div class="def">
+          <span class="sig">SkipPresolve bool</span>
+          <p>When <code>true</code>, <code>Solve</code> bypasses the v0.2 presolve pass (fixed-variable substitution, empty-row/empty-column removal). Off by default. Useful for debugging solver behaviour or for reproducing results against an external reference; most callers should leave it alone. See <a href="./solving.html#presolve">Presolve</a>.</p>
+        </div>
       </div>
 
       <h3>Construction</h3>
@@ -271,6 +275,25 @@
         <div class="def">
           <span class="sig">func (p *Problem) Solve() (*Result, error)</span>
           <p>Runs <code>p.Solver</code> (or the default simplex). Returns <code>(*Result, nil)</code> for any logical outcome including <code>Infeasible</code>/<code>Unbounded</code>; non-nil <code>error</code> is reserved for structural model mistakes. See <a href="./solving.html">Solve and Result</a>.</p>
+        </div>
+        <div class="def">
+          <span class="sig">func (p *Problem) Presolve(opts *PresolveOptions) (*Problem, *PresolveUndo, error)</span>
+          <p>Runs the presolve pass and returns a reduced copy of <code>p</code> plus the undo map required to re-expand a <code>Result</code>. Never mutates <code>p</code>. <code>Solve</code> invokes this automatically unless <code>p.SkipPresolve</code> is <code>true</code>. See <a href="./solving.html#presolve">Presolve</a>.</p>
+        </div>
+        <div class="def">
+          <span class="sig">type PresolveOptions struct {
+  Tolerance float64
+}</span>
+          <p>Configuration for <code>Presolve</code>. <code>Tolerance</code> (default <code>1e-9</code>) is the slack used for feasibility and zero checks on reduced rows. Passing <code>nil</code> is equivalent to passing the zero value.</p>
+        </div>
+        <div class="def">
+          <span class="sig">type PresolveUndo struct {
+  Terminal    Status
+  TerminalMsg string
+  // unexported: the original problem, settled variable values,
+  // reduced↔original handle maps, dropped constraints, objective shift.
+}</span>
+          <p>Undo record produced by <code>Presolve</code>. <code>Terminal</code> is non-<code>NotSolved</code> when the pass decided the problem's status on its own — <code>Infeasible</code> for an inconsistent empty row, <code>Unbounded</code> for a free objective-only variable, <code>Optimal</code> when every variable was fixed. <code>Solve</code> uses the undo record to re-expand <code>Value</code> and duals to the original index space automatically.</p>
         </div>
       </div>
 

--- a/docs/guide/solving.html
+++ b/docs/guide/solving.html
@@ -169,11 +169,12 @@ res, _ := prob.Solve()
       <h2>Solver options</h2>
 
       <p>
-        Two settings live on the <code>Problem</code> itself:
+        Three settings live on the <code>Problem</code> itself:
       </p>
 
 <pre><code class="language-go">prob.Verbose       = true  // stream pivots to stderr (see above)
 prob.MaxIterations = 10000 // hard pivot cap; default is unbounded
+prob.SkipPresolve  = true  // bypass the pre-simplex reduction pass (v0.2)
 </code></pre>
 
       <p>
@@ -183,10 +184,84 @@ prob.MaxIterations = 10000 // hard pivot cap; default is unbounded
       </p>
 
       <p>
-        The third dial is <code>prob.Solver</code> — a slot for an
+        The fourth dial is <code>prob.Solver</code> — a slot for an
         alternative implementation of the <code>grove.Solver</code>
         interface (the pure-Go simplex is the default). That&rsquo;s
         covered in <a href="./file-io.html">File I/O and solvers</a>.
+      </p>
+
+      <h2 id="presolve">Presolve</h2>
+
+      <p>
+        Before the simplex runs, <code>Solve</code> invokes a cheap
+        presolve pass that shrinks the model in three ways:
+      </p>
+
+      <ul>
+        <li>
+          <strong>Fixed variables.</strong> A variable declared with
+          <code>Bounds(c, c)</code> is substituted out: its constant
+          contribution is folded into every constraint&rsquo;s RHS
+          and into the objective constant.
+        </li>
+        <li>
+          <strong>Empty columns.</strong> A variable that — after
+          fixed-variable substitution — appears in no constraint is
+          settled at whichever bound minimises its objective
+          contribution. A positive coefficient in a minimisation
+          pins it to the lower bound; a negative coefficient pins it
+          to the upper bound; a zero coefficient leaves it at the
+          lower bound. If the improving direction is unbounded
+          (e.g. a free variable with a nonzero objective coefficient
+          that never appears in a constraint), presolve returns a
+          <code>Result</code> with <code>Status == Unbounded</code>
+          without ever touching the simplex.
+        </li>
+        <li>
+          <strong>Empty rows.</strong> A constraint whose LHS
+          contains only fixed variables collapses to a scalar
+          comparison (e.g. <code>0 ≤ 5</code>). If it is consistent
+          the constraint is dropped and its dual is reported as
+          <code>0</code>; if it is not (<code>0 ≥ 5</code>) presolve
+          returns a <code>Result</code> with
+          <code>Status == Infeasible</code>.
+        </li>
+      </ul>
+
+      <p>
+        Presolve is transparent: it never mutates the
+        <code>Problem</code> you built, and the <code>Result</code>
+        that <code>Solve</code> returns is re-expanded into your
+        original index space. Fixed and empty-column variables
+        carry their settled value on <code>res.Value(v)</code>; dropped
+        constraints carry a zero <code>res.Dual(c)</code>.
+      </p>
+
+      <p>
+        If you need to drive the pass by hand — for debugging, or to
+        inspect the reduced model before it reaches the solver — call
+        <code>Presolve</code> directly:
+      </p>
+
+<pre><code class="language-go">reduced, undo, err := prob.Presolve(nil)
+if err != nil {
+    return err
+}
+if undo.Terminal != grove.NotSolved {
+    // Presolve proved Infeasible / Unbounded / all-fixed-Optimal
+    // before the simplex ever needed to run.
+    return handleTerminal(undo)
+}
+// ... run reduced.Solve() or inspect reduced.Constraints() ...
+</code></pre>
+
+      <p>
+        Turn presolve off by setting
+        <code>prob.SkipPresolve = true</code>. You almost never
+        want to — the pass is <span class="mono">O(nnz)</span> cheap
+        and frequently saves the simplex a handful of degenerate
+        pivots — but the dial exists for anyone comparing grove
+        against a reference that solves the unreduced model.
       </p>
 
       <h2>Errors vs. logical outcomes</h2>

--- a/docs/guide/solving.html
+++ b/docs/guide/solving.html
@@ -207,15 +207,18 @@ prob.SkipPresolve  = true  // bypass the pre-simplex reduction pass (v0.2)
         <li>
           <strong>Empty columns.</strong> A variable that — after
           fixed-variable substitution — appears in no constraint is
-          settled at whichever bound minimises its objective
-          contribution. A positive coefficient in a minimisation
-          pins it to the lower bound; a negative coefficient pins it
-          to the upper bound; a zero coefficient leaves it at the
-          lower bound. If the improving direction is unbounded
-          (e.g. a free variable with a nonzero objective coefficient
-          that never appears in a constraint), presolve returns a
-          <code>Result</code> with <code>Status == Unbounded</code>
-          without ever touching the simplex.
+          settled at whichever bound improves the user-sense
+          objective. For a <code>Minimize</code> problem a positive
+          coefficient pins the variable at its lower bound and a
+          negative coefficient pins it at its upper bound; for
+          <code>Maximize</code> the signs flip. A zero coefficient
+          leaves the variable at its lower bound (or the upper bound
+          if the lower is <code>-Inf</code>). If the improving
+          direction is unbounded — for example, a free variable with
+          a nonzero objective coefficient that never appears in a
+          constraint — presolve returns a <code>Result</code> with
+          <code>Status == Unbounded</code> without ever touching the
+          simplex.
         </li>
         <li>
           <strong>Empty rows.</strong> A constraint whose LHS

--- a/grove.go
+++ b/grove.go
@@ -258,6 +258,15 @@ type Problem struct {
 	// MaxIterations caps the simplex iteration count. Zero means
 	// "use the solver default".
 	MaxIterations int
+
+	// SkipPresolve disables the pre-simplex reduction pass run by
+	// [Problem.Solve]. The presolve pass (added in v0.2) removes
+	// fixed variables, empty columns, and empty rows before the
+	// solver sees the model; it is cheap and safe for well-formed
+	// LPs, but callers debugging the solver or comparing against
+	// external references may want to turn it off. See
+	// [Problem.Presolve].
+	SkipPresolve bool
 }
 
 // NewProblem returns an empty LP with the given name and optimization sense.
@@ -492,11 +501,31 @@ func (p *Problem) Solve() (*Result, error) {
 	if err := p.Validate(); err != nil {
 		return &Result{Status: NotSolved, Message: err.Error()}, err
 	}
+
+	// Presolve runs by default; SkipPresolve = true bypasses it.
+	target := p
+	var undo *PresolveUndo
+	if !p.SkipPresolve {
+		rp, u, err := p.Presolve(nil)
+		if err != nil {
+			return &Result{Status: NotSolved, Message: err.Error()}, err
+		}
+		undo = u
+		if u.Terminal != NotSolved {
+			res := u.terminalResult()
+			return res, nil
+		}
+		target = rp
+	}
+
 	solver := p.Solver
 	if solver == nil {
 		solver = &SimplexSolver{Verbose: p.Verbose, MaxIterations: p.MaxIterations}
 	}
-	res, err := solver.Solve(p)
+	res, err := solver.Solve(target)
+	if undo != nil {
+		res = undo.expand(res)
+	}
 	if res != nil && res.Status == Optimal {
 		if off := res.NonIntegerIntegerVars(p); len(off) > 0 {
 			w := fmt.Sprintf("%s: %d integer/binary variable(s) came back non-integer "+

--- a/grove.go
+++ b/grove.go
@@ -505,26 +505,34 @@ func (p *Problem) Solve() (*Result, error) {
 	// Presolve runs by default; SkipPresolve = true bypasses it.
 	target := p
 	var undo *PresolveUndo
+	var res *Result
+	var err error
 	if !p.SkipPresolve {
-		rp, u, err := p.Presolve(nil)
-		if err != nil {
-			return &Result{Status: NotSolved, Message: err.Error()}, err
+		rp, u, perr := p.Presolve(nil)
+		if perr != nil {
+			return &Result{Status: NotSolved, Message: perr.Error()}, perr
 		}
 		undo = u
 		if u.Terminal != NotSolved {
-			res := u.terminalResult()
-			return res, nil
+			// Presolve decided the problem's status on its own; build
+			// the expanded Result from the undo map and fall through to
+			// the shared post-solve section so checks like the ILP
+			// warning apply uniformly.
+			res = u.terminalResult()
+		} else {
+			target = rp
 		}
-		target = rp
 	}
 
-	solver := p.Solver
-	if solver == nil {
-		solver = &SimplexSolver{Verbose: p.Verbose, MaxIterations: p.MaxIterations}
-	}
-	res, err := solver.Solve(target)
-	if undo != nil {
-		res = undo.expand(res)
+	if res == nil {
+		solver := p.Solver
+		if solver == nil {
+			solver = &SimplexSolver{Verbose: p.Verbose, MaxIterations: p.MaxIterations}
+		}
+		res, err = solver.Solve(target)
+		if undo != nil {
+			res = undo.expand(res)
+		}
 	}
 	if res != nil && res.Status == Optimal {
 		if off := res.NonIntegerIntegerVars(p); len(off) > 0 {

--- a/presolve.go
+++ b/presolve.go
@@ -1,0 +1,393 @@
+package grove
+
+// This file implements grove's presolve pass. Presolve cheaply shrinks a
+// problem before the simplex runs: it detects fixed variables (low ==
+// high), eliminates empty columns (variables that never appear in any
+// constraint), and drops empty rows (constraints whose LHS has collapsed
+// after fixed-variable substitution). The textbook references are
+// Bertsimas & Tsitsiklis §4.11 on "problem reduction" and Achterberg's
+// 2007 PhD thesis "Constraint Integer Programming" §10.3 for a modern
+// tour of the cheap reductions every serious LP/MIP solver ships with.
+//
+// v0.2 scope (tracked in #5) is deliberately narrow: only the three
+// reductions above, no propagation of variable bounds through
+// constraints, no singleton-row substitution, no duplicate-column
+// detection. Future releases can pile more passes onto the same Presolve
+// entry point without changing its signature.
+
+import (
+	"fmt"
+	"math"
+)
+
+// PresolveOptions configures the presolve pass run by [Problem.Presolve]
+// and, implicitly, by [Problem.Solve]. All fields are optional.
+type PresolveOptions struct {
+	// Tolerance is the slack used for feasibility and zero checks on
+	// reduced rows (e.g. a row that collapses to 0 = rhs is infeasible
+	// when |rhs| > Tolerance). Defaults to 1e-9.
+	Tolerance float64
+}
+
+// PresolveUndo carries the mapping required to re-expand a
+// reduced-problem [Result] back into the original index space. Callers
+// rarely build one directly: [Problem.Presolve] returns it and
+// [Problem.Solve] threads it through transparently.
+//
+// The zero value is not useful; always obtain a PresolveUndo from
+// [Problem.Presolve].
+type PresolveUndo struct {
+	// orig is the Problem the presolve was run on.
+	orig *Problem
+
+	// varValue holds presolve-determined values: the union of fixed
+	// variables (low == high) and empty-column variables whose
+	// optimum is read off their objective coefficient and bounds.
+	// Any original variable not in this map survived presolve and its
+	// value is carried by the reduced [Result].
+	varValue map[*Var]float64
+
+	// varMap maps a surviving reduced *Var back to the original *Var.
+	varMap map[*Var]*Var
+
+	// consMap maps a surviving reduced *Constraint back to the original.
+	consMap map[*Constraint]*Constraint
+
+	// droppedCons records the original constraints the presolve
+	// removed (empty-row eliminations). These carry a zero dual in the
+	// expanded [Result], matching the fact that relaxing a redundant
+	// row does not improve the objective.
+	droppedCons []*Constraint
+
+	// objShift is the constant piece of the objective folded out by
+	// substituting fixed-variable values, reported in the user sense.
+	objShift float64
+
+	// Terminal, when non-zero (i.e. not NotSolved), signals that
+	// presolve decided the problem's status on its own — an empty row
+	// with an inconsistent RHS is [Infeasible]; a free variable that
+	// only appears in the objective is [Unbounded]; an all-fixed model
+	// is [Optimal]. The reduced Problem is nil in those cases and
+	// [Problem.Solve] synthesises a Result directly from the undo map.
+	Terminal    Status
+	TerminalMsg string
+}
+
+// Presolve returns a reduced copy of p plus the undo map required to
+// re-expand a [Result]. It never mutates p.
+//
+// The reduced Problem has its own fresh *Var and *Constraint handles —
+// passing them to the original Problem's solver would be nonsense. In
+// normal use, call Presolve via [Problem.Solve], which owns both the
+// reduced Problem and the undo map for you.
+//
+// The v0.2 pass performs three reductions:
+//
+//   - Fixed variables. A variable with a finite two-sided bound where
+//     low == high is substituted with that value everywhere (objective
+//     constant and each constraint's RHS).
+//   - Empty columns. A variable that — after fixed-variable substitution
+//     — appears in no constraint is settled at its lower or upper bound
+//     according to the sign of its objective coefficient. If the
+//     settling bound is infinite the problem is unbounded.
+//   - Empty rows. A constraint whose LHS has no surviving variables
+//     after substitution is checked for feasibility (0 ⟂ rhs) and
+//     dropped when feasible.
+//
+// Presolve returns a non-nil [PresolveUndo] even on the terminal paths
+// (all-fixed / infeasible / unbounded) so callers can still recover
+// variable values and the objective shift. When it cannot return a
+// reduced Problem (terminal path, or a malformed model) the reduced
+// Problem pointer is nil and [PresolveUndo.Terminal] is set.
+func (p *Problem) Presolve(opts *PresolveOptions) (*Problem, *PresolveUndo, error) {
+	tol := 1e-9
+	if opts != nil && opts.Tolerance > 0 {
+		tol = opts.Tolerance
+	}
+	undo := &PresolveUndo{
+		orig:     p,
+		varValue: map[*Var]float64{},
+		varMap:   map[*Var]*Var{},
+		consMap:  map[*Constraint]*Constraint{},
+	}
+
+	// ── Step 1: detect fixed variables (finite, low == high). ──────────
+	for _, v := range p.vars {
+		if math.IsInf(v.low, 0) || math.IsInf(v.high, 0) {
+			continue
+		}
+		if v.low == v.high {
+			undo.varValue[v] = v.low
+		}
+	}
+
+	// ── Step 2: walk the constraints, substituting fixed variables into
+	// the RHS. Collect surviving rows; flag empty rows for feasibility
+	// checking.
+	type redRow struct {
+		owner *Constraint
+		terms map[*Var]float64 // keyed by original *Var
+		rhs   float64
+	}
+	reducedRows := make([]redRow, 0, len(p.constraints))
+	for _, c := range p.constraints {
+		rhs := c.rhs
+		terms := map[*Var]float64{}
+		for v, k := range c.expr {
+			if val, fixed := undo.varValue[v]; fixed {
+				rhs -= k * val
+				continue
+			}
+			terms[v] = k
+		}
+		if len(terms) == 0 {
+			if !emptyRowFeasible(c.ctype, rhs, tol) {
+				undo.Terminal = Infeasible
+				undo.TerminalMsg = fmt.Sprintf(
+					"presolve: constraint %q reduces to 0 %s %g after fixed-variable substitution",
+					c.name, c.ctype, rhs)
+				return nil, undo, nil
+			}
+			undo.droppedCons = append(undo.droppedCons, c)
+			continue
+		}
+		reducedRows = append(reducedRows, redRow{owner: c, terms: terms, rhs: rhs})
+	}
+
+	// ── Step 3: empty-column detection. A variable that has no fixed
+	// value and does not appear in any surviving row is optimised on its
+	// own — pin it to whichever bound the objective prefers, or declare
+	// the problem unbounded.
+	appears := map[*Var]bool{}
+	for _, r := range reducedRows {
+		for v := range r.terms {
+			appears[v] = true
+		}
+	}
+	for _, v := range p.vars {
+		if _, fixed := undo.varValue[v]; fixed {
+			continue
+		}
+		if appears[v] {
+			continue
+		}
+		coef := p.objective[v]
+		val, unbounded := emptyColumnValue(p.sense, v, coef, tol)
+		if unbounded {
+			undo.Terminal = Unbounded
+			undo.TerminalMsg = fmt.Sprintf(
+				"presolve: variable %q only appears in the objective and is unbounded in the improving direction",
+				v.name)
+			return nil, undo, nil
+		}
+		undo.varValue[v] = val
+	}
+
+	// If every variable has been settled, presolve has solved the model.
+	// Compute the user-sense objective and short-circuit.
+	if len(undo.varValue) == len(p.vars) {
+		obj := p.objConst
+		for v, k := range p.objective {
+			obj += k * undo.varValue[v]
+		}
+		undo.objShift = obj - p.objConst
+		undo.Terminal = Optimal
+		undo.TerminalMsg = "presolve: all variables fixed"
+		// Synthesize a nominal result objective ride-along isn't our job
+		// here; Solve() reads undo.varValue + objConst + objShift and
+		// builds the Result.
+		return nil, undo, nil
+	}
+
+	// ── Step 4: build the reduced Problem.
+	rp := newReducedProblem(p)
+
+	// Surviving original vars → fresh vars on rp, in declaration order
+	// so the reduced model's Vars() stays intuitive.
+	revVarMap := map[*Var]*Var{}
+	for _, v := range p.vars {
+		if _, fixed := undo.varValue[v]; fixed {
+			continue
+		}
+		nv := rp.NewVar(v.name, v.kind, Bounds(v.low, v.high))
+		revVarMap[v] = nv
+		undo.varMap[nv] = v
+	}
+
+	// Objective: drop fixed-variable terms, fold their contribution into
+	// the objective constant.
+	redObj := Expr{}
+	var objShift float64
+	for v, k := range p.objective {
+		if val, fixed := undo.varValue[v]; fixed {
+			objShift += k * val
+			continue
+		}
+		redObj[revVarMap[v]] = k
+	}
+	// Validate() insists on a non-empty objective; if every coefficient
+	// was on a fixed variable, put a zero term on the first surviving
+	// variable so the reduced model still validates.
+	if len(redObj) == 0 {
+		redObj[rp.vars[0]] = 0
+	}
+	rp.SetObjective(redObj)
+	rp.SetObjectiveConstant(p.objConst + objShift)
+	undo.objShift = objShift
+
+	// Constraints: copy the surviving rows with rewritten var keys.
+	for _, r := range reducedRows {
+		redExpr := make(Expr, len(r.terms))
+		for v, k := range r.terms {
+			redExpr[revVarMap[v]] = k
+		}
+		nc := rp.AddConstraint(r.owner.name, redExpr, r.owner.ctype, r.rhs)
+		undo.consMap[nc] = r.owner
+	}
+
+	return rp, undo, nil
+}
+
+// newReducedProblem returns a fresh *Problem that mirrors p's
+// configuration (name, sense, verbosity, iteration cap) but without any
+// variables or constraints. Solver is intentionally not copied: the
+// reduced problem is plugged back into whatever solver the caller is
+// running, not re-dispatched.
+func newReducedProblem(p *Problem) *Problem {
+	name := p.name
+	if name == "" {
+		name = "presolved"
+	} else {
+		name = name + "_presolved"
+	}
+	rp := NewProblem(name, p.sense)
+	rp.Verbose = p.Verbose
+	rp.MaxIterations = p.MaxIterations
+	rp.SkipPresolve = true // don't recursively presolve the reduced model
+	return rp
+}
+
+// emptyRowFeasible reports whether a constraint of type ctype with LHS
+// identically zero is feasible given the (possibly reduced) RHS.
+func emptyRowFeasible(ctype ConstraintType, rhs, tol float64) bool {
+	switch ctype {
+	case EQ:
+		return math.Abs(rhs) <= tol
+	case LTE:
+		return rhs >= -tol
+	case GTE:
+		return rhs <= tol
+	}
+	return true
+}
+
+// emptyColumnValue returns the value at which an empty-column variable
+// v should be pinned, given its objective coefficient and the problem
+// sense. The bool return is true when the improving direction is
+// unbounded (so the caller must surface [Unbounded]).
+func emptyColumnValue(sense Sense, v *Var, coef, tol float64) (float64, bool) {
+	// Internally we always minimise; flip the coefficient on Maximize.
+	minCoef := coef
+	if sense == Maximize {
+		minCoef = -coef
+	}
+	switch {
+	case math.Abs(minCoef) <= tol:
+		// Indifferent. Prefer lower bound, then upper, then zero.
+		switch {
+		case !math.IsInf(v.low, -1):
+			return v.low, false
+		case !math.IsInf(v.high, 1):
+			return v.high, false
+		default:
+			return 0, false
+		}
+	case minCoef > 0:
+		if math.IsInf(v.low, -1) {
+			return 0, true
+		}
+		return v.low, false
+	default: // minCoef < 0
+		if math.IsInf(v.high, 1) {
+			return 0, true
+		}
+		return v.high, false
+	}
+}
+
+// expand re-projects a [Result] computed on the reduced problem back
+// into the original index space described by u. It is a no-op when u
+// is nil (presolve was disabled).
+//
+// The expanded Result keeps the reduced Result's Status, Objective,
+// Iterations, Message, and Warnings. Variable values and reduced costs
+// are keyed on the original *Var handles; constraint duals are keyed
+// on the original *Constraint handles (dropped rows get a zero dual).
+func (u *PresolveUndo) expand(res *Result) *Result {
+	if u == nil || res == nil {
+		return res
+	}
+	out := &Result{
+		Status:     res.Status,
+		Objective:  res.Objective,
+		Iterations: res.Iterations,
+		Message:    res.Message,
+		Warnings:   append([]string(nil), res.Warnings...),
+		values:     map[*Var]float64{},
+		dual:       map[*Constraint]float64{},
+		reduced:    map[*Var]float64{},
+	}
+	// Variables settled by presolve.
+	for v, val := range u.varValue {
+		out.values[v] = val
+	}
+	// Variables carried through from the reduced solve.
+	for rv, ov := range u.varMap {
+		out.values[ov] = res.values[rv]
+		out.reduced[ov] = res.reduced[rv]
+	}
+	// Constraints carried through from the reduced solve.
+	for rc, oc := range u.consMap {
+		out.dual[oc] = res.dual[rc]
+	}
+	// Dropped constraints: zero dual.
+	for _, oc := range u.droppedCons {
+		out.dual[oc] = 0
+	}
+	return out
+}
+
+// terminalResult synthesises a [Result] for the cases where Presolve
+// decided the problem's status unilaterally (all variables fixed,
+// infeasibility, or unboundedness). Returns nil for non-terminal undo
+// maps.
+func (u *PresolveUndo) terminalResult() *Result {
+	if u == nil || u.Terminal == NotSolved {
+		return nil
+	}
+	res := &Result{
+		Status:  u.Terminal,
+		Message: u.TerminalMsg,
+		values:  map[*Var]float64{},
+		dual:    map[*Constraint]float64{},
+		reduced: map[*Var]float64{},
+	}
+	// Variable values we know (populated on any terminal path).
+	for v, val := range u.varValue {
+		res.values[v] = val
+	}
+	// Dropped constraints have zero dual on every terminal path.
+	for _, oc := range u.droppedCons {
+		res.dual[oc] = 0
+	}
+	if u.Terminal == Optimal && u.orig != nil {
+		// Compute the final objective from the original problem's
+		// coefficients.
+		obj := u.orig.objConst
+		for v, k := range u.orig.objective {
+			obj += k * u.varValue[v]
+		}
+		res.Objective = obj
+	}
+	return res
+}

--- a/presolve.go
+++ b/presolve.go
@@ -95,10 +95,13 @@ type PresolveUndo struct {
 //     dropped when feasible.
 //
 // Presolve returns a non-nil [PresolveUndo] even on the terminal paths
-// (all-fixed / infeasible / unbounded) so callers can still recover
-// variable values and the objective shift. When it cannot return a
+// (all-fixed / infeasible / unbounded). When it cannot return a
 // reduced Problem (terminal path, or a malformed model) the reduced
-// Problem pointer is nil and [PresolveUndo.Terminal] is set.
+// Problem pointer is nil and [PresolveUndo.Terminal] is set. Callers
+// that want to synthesize a [Result] from a terminal undo directly —
+// without going back through [Problem.Solve] — can pass the undo to
+// [Problem.Solve] (which handles this path transparently) or inspect
+// [PresolveUndo.Terminal] and [PresolveUndo.TerminalMsg] themselves.
 func (p *Problem) Presolve(opts *PresolveOptions) (*Problem, *PresolveUndo, error) {
 	tol := 1e-9
 	if opts != nil && opts.Tolerance > 0 {
@@ -193,9 +196,10 @@ func (p *Problem) Presolve(opts *PresolveOptions) (*Problem, *PresolveUndo, erro
 		undo.objShift = obj - p.objConst
 		undo.Terminal = Optimal
 		undo.TerminalMsg = "presolve: all variables fixed"
-		// Synthesize a nominal result objective ride-along isn't our job
-		// here; Solve() reads undo.varValue + objConst + objShift and
-		// builds the Result.
+		// Solve() synthesizes the terminal Result by calling
+		// undo.terminalResult(), which recomputes the user-sense
+		// objective directly from undo.varValue and the original
+		// problem's objective coefficients / constant.
 		return nil, undo, nil
 	}
 

--- a/presolve_test.go
+++ b/presolve_test.go
@@ -148,11 +148,10 @@ func TestPresolveEmptyRowInfeasible(t *testing.T) {
 //	     x, y >= 0
 //	     k ∈ [0, 7]
 //
-// Presolve settles k = 0 (we're maximising; coefficient on k is +3;
-// maximising 3k with bounds [0, 7] wants the upper bound 7 though).
-// Wait — for Maximize with +3 coefficient we want k at its upper
-// bound. Optimum: k = 7, objective piece from k = 21. Then the LP
-// degenerates to max 5x - 2y with x+y <= 10 → x=10, y=0. Total = 71.
+// For a Maximize sense with a positive coefficient on k, presolve
+// pins k at its upper bound 7, contributing 3·7 = 21 to the
+// objective. The residual LP becomes max 5x - 2y s.t. x+y <= 10,
+// whose optimum is x=10, y=0. Total objective = 50 + 21 = 71.
 func TestPresolveObjectiveOnlyVariable(t *testing.T) {
 	p := NewProblem("obj_only", Maximize)
 	x := p.NewVar("x", Continuous)
@@ -258,5 +257,40 @@ func TestPresolveAllVariablesFixed(t *testing.T) {
 	}
 	if res.Iterations != 0 {
 		t.Errorf("iterations = %d, want 0 (simplex should not run)", res.Iterations)
+	}
+}
+
+// TestPresolveTerminalOptimalIntegralityWarning: when presolve fully
+// solves a model by fixing every variable, the post-solve integrality
+// check must still fire. Here an Integer variable is pinned to 0.5 by
+// its bounds, which is LP-feasible but not ILP-feasible; Solve() must
+// surface the v0.1 WarnLPRelaxationOnly warning even though the
+// simplex never ran.
+func TestPresolveTerminalOptimalIntegralityWarning(t *testing.T) {
+	p := NewProblem("fixed_noninteger", Minimize)
+	x := p.NewVar("x", Integer, Bounds(0.5, 0.5))
+	p.SetObjective(Expr{x: 1})
+	p.AddConstraint("trivial", Expr{x: 1}, GTE, 0)
+
+	res, err := p.Solve()
+	if err != nil || res.Status != Optimal {
+		t.Fatalf("Solve: status=%v err=%v", res.Status, err)
+	}
+	if res.Iterations != 0 {
+		t.Errorf("iterations = %d, want 0 (terminal-Optimal path)", res.Iterations)
+	}
+	if !approxEq(res.Value(x), 0.5) {
+		t.Errorf("x = %g, want 0.5", res.Value(x))
+	}
+	var gotWarn bool
+	for _, w := range res.Warnings {
+		if strings.HasPrefix(w, WarnLPRelaxationOnly) {
+			gotWarn = true
+			break
+		}
+	}
+	if !gotWarn {
+		t.Errorf("expected %q warning on terminal-Optimal presolve path; got Warnings=%v Message=%q",
+			WarnLPRelaxationOnly, res.Warnings, res.Message)
 	}
 }

--- a/presolve_test.go
+++ b/presolve_test.go
@@ -1,0 +1,262 @@
+package grove
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// TestPresolveFixedVariable checks that a variable with low == high is
+// substituted into the RHS of every constraint and into the objective
+// constant, and its value is restored in the expanded result.
+func TestPresolveFixedVariable(t *testing.T) {
+	// min  2x + 3y + 10z
+	// s.t. x + y + z >= 5
+	//      y <= 4
+	//      x ∈ [0, Inf], y ∈ [0, Inf], z ∈ [2, 2]   ← z is fixed
+	//
+	// Substituting z = 2: min 2x + 3y + 20, x + y >= 3, y <= 4.
+	// Optimum: x = 3, y = 0, z = 2, objective = 26.
+	p := NewProblem("fixed_var", Minimize)
+	x := p.NewVar("x", Continuous)
+	y := p.NewVar("y", Continuous)
+	z := p.NewVar("z", Continuous, Bounds(2, 2))
+	p.SetObjective(Expr{x: 2, y: 3, z: 10})
+	cSum := p.AddConstraint("sum", Expr{x: 1, y: 1, z: 1}, GTE, 5)
+	p.AddConstraint("y_cap", Expr{y: 1}, LTE, 4)
+
+	// Check presolve output directly.
+	rp, undo, err := p.Presolve(nil)
+	if err != nil {
+		t.Fatalf("Presolve: %v", err)
+	}
+	if undo == nil {
+		t.Fatal("nil undo")
+	}
+	if got, want := undo.varValue[z], 2.0; got != want {
+		t.Errorf("undo.varValue[z] = %g, want %g", got, want)
+	}
+	if rp == nil {
+		t.Fatal("expected a reduced problem")
+	}
+	if len(rp.vars) != 2 {
+		t.Errorf("reduced vars = %d, want 2", len(rp.vars))
+	}
+	// The reduced "sum" constraint should have rhs 3, not 5.
+	rc := rp.ConstraintByName("sum")
+	if rc == nil {
+		t.Fatal("sum constraint missing from reduced problem")
+	}
+	if rc.rhs != 3 {
+		t.Errorf("reduced sum rhs = %g, want 3", rc.rhs)
+	}
+
+	// End-to-end solve: Solve() should drive the presolve + expand path.
+	res, err := p.Solve()
+	if err != nil || res.Status != Optimal {
+		t.Fatalf("Solve: status=%v err=%v", res.Status, err)
+	}
+	if !approxEq(res.Objective, 26) {
+		t.Errorf("objective = %g, want 26", res.Objective)
+	}
+	if !approxEq(res.Value(z), 2) {
+		t.Errorf("z value = %g, want 2", res.Value(z))
+	}
+	if !approxEq(res.Value(x), 3) {
+		t.Errorf("x value = %g, want 3", res.Value(x))
+	}
+	if !approxEq(res.Value(y), 0) {
+		t.Errorf("y value = %g, want 0", res.Value(y))
+	}
+	// Duals on the original constraints must still be addressable by
+	// the original handles.
+	if math.IsNaN(res.Dual(cSum)) {
+		t.Errorf("dual(sum) is NaN")
+	}
+}
+
+// TestPresolveEmptyRow: a constraint that is satisfied trivially by
+// problem structure (LTE with RHS ≥ 0 and all fixed LHS terms) should
+// be dropped by presolve and its dual reported as zero.
+func TestPresolveEmptyRow(t *testing.T) {
+	// min  x + y
+	// s.t. x + y >= 3                (real constraint)
+	//      z <= 100                  (empty-row once z is fixed)
+	//      z ∈ [1, 1]                (z is fixed to 1)
+	//      x, y >= 0
+	p := NewProblem("empty_row", Minimize)
+	x := p.NewVar("x", Continuous)
+	y := p.NewVar("y", Continuous)
+	z := p.NewVar("z", Continuous, Bounds(1, 1))
+	p.SetObjective(Expr{x: 1, y: 1})
+	p.AddConstraint("need", Expr{x: 1, y: 1}, GTE, 3)
+	cTrivial := p.AddConstraint("trivial", Expr{z: 1}, LTE, 100)
+
+	rp, undo, err := p.Presolve(nil)
+	if err != nil {
+		t.Fatalf("Presolve: %v", err)
+	}
+	if rp.ConstraintByName("trivial") != nil {
+		t.Errorf("trivial constraint should have been dropped")
+	}
+	if len(undo.droppedCons) != 1 || undo.droppedCons[0] != cTrivial {
+		t.Errorf("droppedCons = %v", undo.droppedCons)
+	}
+
+	// Solve end-to-end; dual of the dropped constraint must read as 0.
+	res, err := p.Solve()
+	if err != nil || res.Status != Optimal {
+		t.Fatalf("Solve: status=%v err=%v", res.Status, err)
+	}
+	if !approxEq(res.Objective, 3) {
+		t.Errorf("objective = %g, want 3", res.Objective)
+	}
+	if res.Dual(cTrivial) != 0 {
+		t.Errorf("dual(trivial) = %g, want 0", res.Dual(cTrivial))
+	}
+}
+
+// TestPresolveEmptyRowInfeasible: a row that becomes 0 > 5 after
+// substitution must surface as Infeasible without ever touching the
+// simplex.
+func TestPresolveEmptyRowInfeasible(t *testing.T) {
+	p := NewProblem("bad_row", Minimize)
+	x := p.NewVar("x", Continuous)
+	z := p.NewVar("z", Continuous, Bounds(0, 0))
+	p.SetObjective(Expr{x: 1})
+	p.AddConstraint("ok", Expr{x: 1}, GTE, 1)
+	// After z = 0 this row says 0 >= 5, which is infeasible.
+	p.AddConstraint("bad", Expr{z: 1}, GTE, 5)
+
+	res, err := p.Solve()
+	if err != nil {
+		t.Fatalf("Solve returned error: %v", err)
+	}
+	if res.Status != Infeasible {
+		t.Errorf("status = %v, want Infeasible", res.Status)
+	}
+	if !strings.Contains(res.Message, "bad") {
+		t.Errorf("message should mention the offending constraint; got %q", res.Message)
+	}
+}
+
+// TestPresolveObjectiveOnlyVariable: a variable that appears only in
+// the objective is pinned to its best bound by presolve.
+//
+//	max  5x - 2y + 3k     (k only appears in the objective)
+//	s.t. x + y <= 10
+//	     x, y >= 0
+//	     k ∈ [0, 7]
+//
+// Presolve settles k = 0 (we're maximising; coefficient on k is +3;
+// maximising 3k with bounds [0, 7] wants the upper bound 7 though).
+// Wait — for Maximize with +3 coefficient we want k at its upper
+// bound. Optimum: k = 7, objective piece from k = 21. Then the LP
+// degenerates to max 5x - 2y with x+y <= 10 → x=10, y=0. Total = 71.
+func TestPresolveObjectiveOnlyVariable(t *testing.T) {
+	p := NewProblem("obj_only", Maximize)
+	x := p.NewVar("x", Continuous)
+	y := p.NewVar("y", Continuous)
+	k := p.NewVar("k", Continuous, Bounds(0, 7))
+	p.SetObjective(Expr{x: 5, y: -2, k: 3})
+	p.AddConstraint("cap", Expr{x: 1, y: 1}, LTE, 10)
+
+	rp, undo, err := p.Presolve(nil)
+	if err != nil {
+		t.Fatalf("Presolve: %v", err)
+	}
+	if got, want := undo.varValue[k], 7.0; got != want {
+		t.Errorf("presolved k value = %g, want %g", got, want)
+	}
+	// k must not appear in the reduced model.
+	for _, rv := range rp.vars {
+		if rv.name == "k" {
+			t.Errorf("k should have been eliminated from the reduced model")
+		}
+	}
+
+	res, err := p.Solve()
+	if err != nil || res.Status != Optimal {
+		t.Fatalf("Solve: status=%v err=%v", res.Status, err)
+	}
+	if !approxEq(res.Objective, 5*10+3*7) {
+		t.Errorf("objective = %g, want %g", res.Objective, 5*10+3*7.0)
+	}
+	if !approxEq(res.Value(k), 7) {
+		t.Errorf("k = %g, want 7", res.Value(k))
+	}
+	if !approxEq(res.Value(x), 10) {
+		t.Errorf("x = %g, want 10", res.Value(x))
+	}
+}
+
+// TestPresolveObjectiveOnlyUnbounded: a free variable that only
+// appears in the objective proves unboundedness without touching the
+// simplex.
+func TestPresolveObjectiveOnlyUnbounded(t *testing.T) {
+	p := NewProblem("unbounded_k", Maximize)
+	x := p.NewVar("x", Continuous)
+	k := p.NewVar("k", Continuous, Bounds(-Inf, Inf))
+	p.SetObjective(Expr{x: 1, k: 1})
+	p.AddConstraint("cap", Expr{x: 1}, LTE, 5)
+
+	res, err := p.Solve()
+	if err != nil {
+		t.Fatalf("Solve returned error: %v", err)
+	}
+	if res.Status != Unbounded {
+		t.Errorf("status = %v, want Unbounded", res.Status)
+	}
+	if !strings.Contains(res.Message, "k") {
+		t.Errorf("message should mention the offending variable; got %q", res.Message)
+	}
+}
+
+// TestSkipPresolve: setting SkipPresolve = true should bypass the
+// presolve pass entirely and still yield a correct optimum. This
+// keeps the option honest as a debugging dial.
+func TestSkipPresolve(t *testing.T) {
+	p := NewProblem("skip_presolve", Minimize)
+	x := p.NewVar("x", Continuous)
+	y := p.NewVar("y", Continuous)
+	z := p.NewVar("z", Continuous, Bounds(2, 2))
+	p.SetObjective(Expr{x: 2, y: 3, z: 10})
+	p.AddConstraint("sum", Expr{x: 1, y: 1, z: 1}, GTE, 5)
+	p.AddConstraint("y_cap", Expr{y: 1}, LTE, 4)
+	p.SkipPresolve = true
+
+	res, err := p.Solve()
+	if err != nil || res.Status != Optimal {
+		t.Fatalf("Solve: status=%v err=%v", res.Status, err)
+	}
+	if !approxEq(res.Objective, 26) {
+		t.Errorf("objective = %g, want 26", res.Objective)
+	}
+	if !approxEq(res.Value(z), 2) {
+		t.Errorf("z = %g, want 2", res.Value(z))
+	}
+}
+
+// TestPresolveAllVariablesFixed: a model where every variable is
+// pinned by its bounds (low == high) is fully solved by presolve; the
+// simplex never runs.
+func TestPresolveAllVariablesFixed(t *testing.T) {
+	p := NewProblem("all_fixed", Minimize)
+	x := p.NewVar("x", Continuous, Bounds(3, 3))
+	y := p.NewVar("y", Continuous, Bounds(-1, -1))
+	p.SetObjective(Expr{x: 2, y: 5})
+	p.SetObjectiveConstant(1)
+	// Redundant constraint that survives substitution as an empty row.
+	p.AddConstraint("ok", Expr{x: 1, y: 1}, LTE, 100)
+
+	res, err := p.Solve()
+	if err != nil || res.Status != Optimal {
+		t.Fatalf("Solve: status=%v err=%v", res.Status, err)
+	}
+	if !approxEq(res.Objective, 2*3+5*-1+1) {
+		t.Errorf("objective = %g, want %g", res.Objective, 2*3+5*-1+1.0)
+	}
+	if res.Iterations != 0 {
+		t.Errorf("iterations = %d, want 0 (simplex should not run)", res.Iterations)
+	}
+}


### PR DESCRIPTION
Closes #5

Adds Problem.Presolve(opts) returning a reduced Problem plus an undo map. Solve() runs the pass by default; set SkipPresolve = true to bypass. The v0.2 pass handles three cheap reductions:

- Fixed variables (low == high) are substituted into every constraint's RHS and into the objective constant.
- Empty columns (variables that appear in no constraint after substitution) are pinned to the objective-preferred bound; a free objective-only variable short-circuits to Unbounded.
- Empty rows (constraints whose LHS has no surviving variables) are feasibility-checked and dropped; an inconsistent empty row short-circuits to Infeasible without running the simplex.

The undo record re-expands Result.Value/Dual to the original index space, so callers keep using their original *Var and *Constraint handles. Presolve is O(nnz) and the simplex sees a strictly smaller model.

Docs updated: new "Presolve" subsection in guide/solving.html, new Presolve / PresolveOptions / PresolveUndo / SkipPresolve entries in guide/api-reference.html, and the v0.2 ROADMAP bullet is now checked.