### PR TITLE
v0.2: expanded problem validation (closes #6)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ Target: **Q3.** Backwards-compatible additions only. Epic: [#24](https://github.
 - [x] Presolve pass that drops empty rows/columns and detects fixed
   variables before the simplex starts.
   ([#5](https://github.com/JakenHerman/grove/issues/5))
-- Constraint validation upgrades: detect duplicates, empty rows,
+- [x] Constraint validation upgrades: detect duplicates, empty rows,
   zero-only objectives, NaN/Inf coefficients.
   ([#6](https://github.com/JakenHerman/grove/issues/6))
 

--- a/docs/guide/api-reference.html
+++ b/docs/guide/api-reference.html
@@ -269,8 +269,57 @@
 
       <div class="def-grid">
         <div class="def">
-          <span class="sig">func (p *Problem) Validate() error</span>
-          <p>Runs the sanity checks (non-empty variables/constraints, unique names, no inverted <code>Bounds</code>, non-nil objective, no cross-problem <code>*Var</code>s). Automatically invoked at the top of <code>Solve</code>.</p>
+          <span class="sig">func (p *Problem) Validate() []error</span>
+          <p>
+            Returns every modeling problem it finds in one pass — an
+            empty/nil slice means the model is valid. The checks cover
+            missing variables/objective, all-zero objective, inverted
+            or NaN bounds, NaN/±Inf objective and constraint
+            coefficients, NaN/±Inf right-hand sides, empty-row and
+            all-zero-row constraints, and duplicate constraint names.
+            Each error is a <code>*ValidationError</code> carrying a
+            stable <code>Kind</code> classifier; see
+            <a href="./modeling.html#validation">Validation</a>.
+            <code>Solve</code> invokes <code>Validate</code>
+            automatically and refuses to run when the returned slice
+            is non-empty.
+          </p>
+        </div>
+        <div class="def">
+          <span class="sig">type ValidationError struct {
+  Kind    ValidationErrorKind
+  Target  string
+  Message string
+}</span>
+          <p>
+            Single issue returned from <code>Problem.Validate</code>.
+            <code>Kind</code> is a stable string classifier;
+            <code>Target</code> is the variable or constraint name (or
+            <code>""</code> for problem-level errors);
+            <code>Message</code> is the human-readable text
+            (<code>Error()</code> returns it verbatim). Pull a specific
+            kind out of a <code>[]error</code> with
+            <code>errors.As(err, &amp;verr)</code>.
+          </p>
+        </div>
+        <div class="def">
+          <span class="sig">type ValidationErrorKind string</span>
+          <p>
+            Stable classifier constants:
+            <code>ValidationNoVariables</code>,
+            <code>ValidationNoObjective</code>,
+            <code>ValidationZeroObjective</code>,
+            <code>ValidationBadBound</code>,
+            <code>ValidationInvertedBounds</code>,
+            <code>ValidationBadObjectiveCoef</code>,
+            <code>ValidationBadRHS</code>,
+            <code>ValidationEmptyRow</code>,
+            <code>ValidationZeroRow</code>,
+            <code>ValidationBadCoefficient</code>,
+            <code>ValidationDuplicateConstraint</code>.
+            See <a href="./modeling.html#validation">Validation</a>
+            for what each one catches.
+          </p>
         </div>
         <div class="def">
           <span class="sig">func (p *Problem) Solve() (*Result, error)</span>

--- a/docs/guide/api-reference.html
+++ b/docs/guide/api-reference.html
@@ -273,10 +273,14 @@
           <p>
             Returns every modeling problem it finds in one pass — an
             empty/nil slice means the model is valid. The checks cover
-            missing variables/objective, all-zero objective, inverted
-            or NaN bounds, NaN/±Inf objective and constraint
-            coefficients, NaN/±Inf right-hand sides, empty-row and
-            all-zero-row constraints, and duplicate constraint names.
+            missing variables/objective (except presolve-reduced models
+            whose linear objective was folded entirely into
+            <code>ObjectiveConstant</code>), all-zero objective when
+            every stated coefficient is finite, inverted bounds and NaN
+            bounds (±<code>Inf</code> remains valid for unbounded sides),
+            NaN/±Inf objective and constraint coefficients, NaN/±Inf
+            right-hand sides, empty LHS rows, all-zero LHS rows when
+            every coefficient is finite, and duplicate constraint names.
             Each error is a <code>*ValidationError</code> carrying a
             stable <code>Kind</code> classifier; see
             <a href="./modeling.html#validation">Validation</a>.

--- a/docs/guide/modeling.html
+++ b/docs/guide/modeling.html
@@ -244,22 +244,106 @@ fmt.Println(res.Dual(budget)) // ∂z*/∂rhs of `budget`
       <h2>Validation</h2>
 
       <p>
-        <code>Validate</code> runs automatically at the top of
+        <code>Problem.Validate</code> runs automatically at the top of
         <code>Solve</code>, but you can call it yourself earlier if
-        you&rsquo;re building a model in pieces:
+        you&rsquo;re building a model in pieces. It returns
+        <code>[]error</code> with <em>every</em> problem found — it
+        never short-circuits on the first failure, so a single call
+        surfaces the whole class of issues at once:
       </p>
 
-<pre><code class="language-go">if err := prob.Validate(); err != nil {
-    return fmt.Errorf("bad model: %w", err)
+<pre><code class="language-go">if errs := prob.Validate(); len(errs) &gt; 0 {
+    for _, err := range errs {
+        log.Println("bad model:", err)
+    }
+    return errors.Join(errs...)
 }
 </code></pre>
 
       <p>
-        The checks it performs today: non-empty variable and
-        constraint lists, unique names, no inverted bounds
-        (<code>low &gt; high</code>), a non-nil objective, and no
-        dangling <code>*Var</code>s that belong to a different
-        <code>Problem</code>.
+        The full list of checks:
+      </p>
+
+      <table>
+        <thead>
+          <tr><th>Kind</th><th>What it catches</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>ValidationNoVariables</code></td>
+            <td>The problem has no variables at all.</td>
+          </tr>
+          <tr>
+            <td><code>ValidationNoObjective</code></td>
+            <td><code>SetObjective</code> was never called (the objective map is empty).</td>
+          </tr>
+          <tr>
+            <td><code>ValidationZeroObjective</code></td>
+            <td>
+              Every objective coefficient is zero. grove treats this as
+              a modeling mistake rather than a silent feasibility
+              problem — add a non-zero coefficient on at least one
+              variable, or drop the objective call entirely and wait
+              for <code>ValidationNoObjective</code>.
+            </td>
+          </tr>
+          <tr>
+            <td><code>ValidationBadBound</code></td>
+            <td>A variable has a NaN bound. <code>±Inf</code> is still valid — that&rsquo;s the sentinel for an unbounded side.</td>
+          </tr>
+          <tr>
+            <td><code>ValidationInvertedBounds</code></td>
+            <td><code>low &gt; high</code> on <code>Bounds</code>, which would leave the variable&rsquo;s domain empty.</td>
+          </tr>
+          <tr>
+            <td><code>ValidationBadObjectiveCoef</code></td>
+            <td>The objective has a NaN or <code>±Inf</code> coefficient.</td>
+          </tr>
+          <tr>
+            <td><code>ValidationBadRHS</code></td>
+            <td>A constraint has a NaN or <code>±Inf</code> right-hand side.</td>
+          </tr>
+          <tr>
+            <td><code>ValidationEmptyRow</code></td>
+            <td>A constraint&rsquo;s LHS is the empty expression <code>Expr{}</code>.</td>
+          </tr>
+          <tr>
+            <td><code>ValidationZeroRow</code></td>
+            <td>A constraint has terms, but every coefficient is zero (<code>Expr{x: 0, y: 0}</code>). These would be dropped by presolve anyway; rejecting up front surfaces the likely modeling typo.</td>
+          </tr>
+          <tr>
+            <td><code>ValidationBadCoefficient</code></td>
+            <td>A constraint has a NaN or <code>±Inf</code> coefficient on one of its variables.</td>
+          </tr>
+          <tr>
+            <td><code>ValidationDuplicateConstraint</code></td>
+            <td>Two or more constraints share the same name. (<code>AddConstraint</code> panics on duplicates at registration time; <code>Validate</code> is the backstop for direct-slice construction and file readers.)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        Each entry in the returned slice is a <code>*ValidationError</code>
+        with a stable <code>Kind</code> field — handy when tooling wants
+        to react to a specific class of issue rather than grepping
+        strings:
+      </p>
+
+<pre><code class="language-go">var verr *grove.ValidationError
+for _, err := range prob.Validate() {
+    if errors.As(err, &amp;verr) &amp;&amp; verr.Kind == grove.ValidationDuplicateConstraint {
+        fixDuplicateName(verr.Target)
+    }
+}
+</code></pre>
+
+      <p>
+        Both <code>NewVar</code> and <code>AddConstraint</code> still
+        panic on duplicate names at registration time; <code>Validate</code>
+        exists to catch the same class of problem when a model is built
+        any other way — a file reader, a test fixture mutating
+        <code>Problem.Constraints</code> directly, or a code generator
+        assembling <code>Problem</code> from parts.
       </p>
 
       <h2>Putting it together</h2>

--- a/docs/guide/modeling.html
+++ b/docs/guide/modeling.html
@@ -280,11 +280,16 @@ fmt.Println(res.Dual(budget)) // ∂z*/∂rhs of `budget`
           <tr>
             <td><code>ValidationZeroObjective</code></td>
             <td>
-              Every objective coefficient is zero. grove treats this as
-              a modeling mistake rather than a silent feasibility
-              problem — add a non-zero coefficient on at least one
-              variable, or drop the objective call entirely and wait
-              for <code>ValidationNoObjective</code>.
+              Every objective coefficient is finite and zero. If any
+              coefficient is NaN or ±Inf, only
+              <code>ValidationBadObjectiveCoef</code> is reported for
+              those terms. grove treats an all-finite-zero objective as
+              a modeling mistake — add a non-zero coefficient on at
+              least one variable, or (for user-built models) drop the
+              objective call entirely and hit <code>ValidationNoObjective</code>.
+              Presolve-reduced problems may legally have an empty objective
+              map when the linear part was folded into
+              <code>SetObjectiveConstant</code>.
             </td>
           </tr>
           <tr>
@@ -309,7 +314,7 @@ fmt.Println(res.Dual(budget)) // ∂z*/∂rhs of `budget`
           </tr>
           <tr>
             <td><code>ValidationZeroRow</code></td>
-            <td>A constraint has terms, but every coefficient is zero (<code>Expr{x: 0, y: 0}</code>). These would be dropped by presolve anyway; rejecting up front surfaces the likely modeling typo.</td>
+            <td>A constraint has a non-empty LHS and every coefficient is finite and zero (<code>Expr{x: 0, y: 0}</code>). Rows with any NaN/±Inf coefficient only report <code>ValidationBadCoefficient</code>, not <code>ValidationZeroRow</code>. These would be dropped by presolve anyway; rejecting up front surfaces the likely modeling typo.</td>
           </tr>
           <tr>
             <td><code>ValidationBadCoefficient</code></td>
@@ -341,9 +346,11 @@ for _, err := range prob.Validate() {
         Both <code>NewVar</code> and <code>AddConstraint</code> still
         panic on duplicate names at registration time; <code>Validate</code>
         exists to catch the same class of problem when a model is built
-        any other way — a file reader, a test fixture mutating
-        <code>Problem.Constraints</code> directly, or a code generator
-        assembling <code>Problem</code> from parts.
+        any other way — a file reader, code inside the
+        <code>grove</code> package that appends to the internal
+        constraint slice, or a test that mutates the live slice returned
+        by <code>Constraints()</code> (the backing array is shared; treat
+        it as read-only unless you know what you&rsquo;re doing).
       </p>
 
       <h2>Putting it together</h2>

--- a/grove.go
+++ b/grove.go
@@ -268,6 +268,13 @@ type Problem struct {
 	// external references may want to turn it off. See
 	// [Problem.Presolve].
 	SkipPresolve bool
+
+	// allowEmptyObjective is set on reduced problems produced by
+	// [Problem.Presolve] when every linear objective term was folded
+	// into [Problem.ObjectiveConstant]. Such models have an empty
+	// objective [Expr] but are still valid for [Problem.Validate] and
+	// the solver. User-built problems never set this flag.
+	allowEmptyObjective bool
 }
 
 // NewProblem returns an empty LP with the given name and optimization sense.
@@ -454,13 +461,17 @@ func (e *ValidationError) Error() string { return e.Message }
 // The checks Validate performs:
 //
 //   - The problem has at least one variable.
-//   - Every variable has finite (non-NaN) bounds and low ≤ high.
-//   - [Problem.SetObjective] was called, and the objective has at
-//     least one non-zero coefficient. All objective coefficients must
-//     be finite.
+//   - Variable bounds must not be NaN; ±Inf is a valid unbounded
+//     sentinel ([Inf]). Inverted intervals (low > high) are rejected.
+//   - For models built only through the public API, [Problem.SetObjective]
+//     must have been called with a non-empty map whose coefficients are
+//     all finite and include at least one non-zero value. Reduced
+//     problems returned from [Problem.Presolve] may legally have an
+//     empty objective map when every linear term was folded into
+//     [Problem.ObjectiveConstant].
 //   - Every constraint has a finite right-hand side, a non-empty LHS
-//     with at least one non-zero coefficient, and finite coefficients
-//     throughout.
+//     with at least one non-zero finite coefficient, and finite
+//     coefficients throughout.
 //   - Constraint names are unique across the problem.
 //
 // Validate never short-circuits: it accumulates every error it can find
@@ -493,14 +504,18 @@ func (p *Problem) Validate() []error {
 	}
 
 	if len(p.objective) == 0 {
-		errs = append(errs, &ValidationError{
-			Kind:    ValidationNoObjective,
-			Message: fmt.Sprintf("grove: problem %q has no objective (call SetObjective)", p.name),
-		})
+		if !p.allowEmptyObjective {
+			errs = append(errs, &ValidationError{
+				Kind:    ValidationNoObjective,
+				Message: fmt.Sprintf("grove: problem %q has no objective (call SetObjective)", p.name),
+			})
+		}
 	} else {
 		nonZero := 0
+		badObjectiveCoef := false
 		for v, coef := range p.objective {
 			if math.IsNaN(coef) || math.IsInf(coef, 0) {
+				badObjectiveCoef = true
 				errs = append(errs, &ValidationError{
 					Kind:    ValidationBadObjectiveCoef,
 					Target:  v.name,
@@ -512,7 +527,7 @@ func (p *Problem) Validate() []error {
 				nonZero++
 			}
 		}
-		if nonZero == 0 {
+		if nonZero == 0 && !badObjectiveCoef {
 			errs = append(errs, &ValidationError{
 				Kind:    ValidationZeroObjective,
 				Message: fmt.Sprintf("grove: problem %q has an all-zero objective (SetObjective needs at least one non-zero coefficient)", p.name),
@@ -569,8 +584,10 @@ func (p *Problem) Validate() []error {
 		}
 
 		hasNonZero := false
+		nonFiniteCoef := false
 		for v, coef := range c.expr {
 			if math.IsNaN(coef) || math.IsInf(coef, 0) {
+				nonFiniteCoef = true
 				errs = append(errs, &ValidationError{
 					Kind:    ValidationBadCoefficient,
 					Target:  c.name,
@@ -582,7 +599,7 @@ func (p *Problem) Validate() []error {
 				hasNonZero = true
 			}
 		}
-		if !hasNonZero {
+		if !hasNonZero && !nonFiniteCoef {
 			errs = append(errs, &ValidationError{
 				Kind:    ValidationZeroRow,
 				Target:  c.name,

--- a/grove.go
+++ b/grove.go
@@ -26,6 +26,7 @@
 package grove
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -380,41 +381,217 @@ func (p *Problem) AddConstraint(name string, e Expr, ctype ConstraintType, rhs f
 // ConstraintByName returns the constraint with the given name, or nil if absent.
 func (p *Problem) ConstraintByName(name string) *Constraint { return p.consNames[name] }
 
-// Validate checks the problem for obvious modeling errors and returns a
-// non-nil error if any are found. [Problem.Solve] runs Validate
-// implicitly; call it directly if you want to fail fast at build time.
-func (p *Problem) Validate() error {
+// ValidationErrorKind classifies a structured validation failure
+// returned from [Problem.Validate]. Use [errors.As] to inspect a
+// specific error returned from the slice.
+type ValidationErrorKind string
+
+// Validation error kinds. These string constants are part of grove's
+// stable surface — callers can switch on them from tooling that wants
+// to present validation issues more richly than a log line.
+const (
+	// ValidationNoVariables: the problem has no variables at all.
+	ValidationNoVariables ValidationErrorKind = "no_variables"
+	// ValidationNoObjective: [Problem.SetObjective] was never called
+	// (the objective map is empty).
+	ValidationNoObjective ValidationErrorKind = "no_objective"
+	// ValidationZeroObjective: every objective coefficient is zero.
+	// grove treats this as a modeling mistake; add a non-zero
+	// coefficient or drop the objective entirely.
+	ValidationZeroObjective ValidationErrorKind = "zero_objective"
+	// ValidationBadBound: a variable has a NaN lower or upper bound.
+	ValidationBadBound ValidationErrorKind = "bad_bound"
+	// ValidationInvertedBounds: a variable's low > high, leaving an
+	// empty domain.
+	ValidationInvertedBounds ValidationErrorKind = "inverted_bounds"
+	// ValidationBadObjectiveCoef: the objective has a NaN or ±Inf
+	// coefficient on some variable.
+	ValidationBadObjectiveCoef ValidationErrorKind = "bad_objective_coefficient"
+	// ValidationBadRHS: a constraint's right-hand side is NaN or ±Inf.
+	ValidationBadRHS ValidationErrorKind = "bad_rhs"
+	// ValidationEmptyRow: a constraint's LHS is an empty expression
+	// (map of length zero).
+	ValidationEmptyRow ValidationErrorKind = "empty_row"
+	// ValidationZeroRow: a constraint's LHS has at least one term but
+	// every coefficient is zero.
+	ValidationZeroRow ValidationErrorKind = "zero_row"
+	// ValidationBadCoefficient: a constraint has a NaN or ±Inf
+	// coefficient on some variable.
+	ValidationBadCoefficient ValidationErrorKind = "bad_coefficient"
+	// ValidationDuplicateConstraint: two or more constraints share
+	// the same name.
+	ValidationDuplicateConstraint ValidationErrorKind = "duplicate_constraint"
+)
+
+// ValidationError is a single problem found by [Problem.Validate].
+// Callers that want to react to a specific class of error (e.g. skip
+// duplicate-name complaints in an auto-generated model) can use
+// [errors.As] to pull one out of the returned slice:
+//
+//	var verr *grove.ValidationError
+//	if errors.As(err, &verr) && verr.Kind == grove.ValidationDuplicateConstraint {
+//	    // ...
+//	}
+type ValidationError struct {
+	// Kind is the stable classifier for this error.
+	Kind ValidationErrorKind
+	// Target is the name of the variable or constraint the error is
+	// about, or "" for problem-level errors.
+	Target string
+	// Message is the human-readable error text.
+	Message string
+}
+
+// Error implements the error interface.
+func (e *ValidationError) Error() string { return e.Message }
+
+// Validate checks the problem for modeling errors and returns every
+// problem it finds. The returned slice is nil/empty when the model is
+// valid. [Problem.Solve] runs Validate implicitly and refuses to solve
+// if the slice is non-empty; call it directly if you want to fail fast
+// at build time or collect every issue before showing the user.
+//
+// The checks Validate performs:
+//
+//   - The problem has at least one variable.
+//   - Every variable has finite (non-NaN) bounds and low ≤ high.
+//   - [Problem.SetObjective] was called, and the objective has at
+//     least one non-zero coefficient. All objective coefficients must
+//     be finite.
+//   - Every constraint has a finite right-hand side, a non-empty LHS
+//     with at least one non-zero coefficient, and finite coefficients
+//     throughout.
+//   - Constraint names are unique across the problem.
+//
+// Validate never short-circuits: it accumulates every error it can find
+// so a single call surfaces the whole class of problems at once.
+func (p *Problem) Validate() []error {
+	var errs []error
+
 	if len(p.vars) == 0 {
-		return fmt.Errorf("grove: problem %q has no variables", p.name)
+		errs = append(errs, &ValidationError{
+			Kind:    ValidationNoVariables,
+			Message: fmt.Sprintf("grove: problem %q has no variables", p.name),
+		})
 	}
+
 	for _, v := range p.vars {
-		if math.IsNaN(v.low) || math.IsNaN(v.high) {
-			return fmt.Errorf("grove: variable %q has NaN bound", v.name)
-		}
-		if v.low > v.high {
-			return fmt.Errorf("grove: variable %q has empty domain [%g, %g]", v.name, v.low, v.high)
+		switch {
+		case math.IsNaN(v.low) || math.IsNaN(v.high):
+			errs = append(errs, &ValidationError{
+				Kind:    ValidationBadBound,
+				Target:  v.name,
+				Message: fmt.Sprintf("grove: variable %q has NaN bound", v.name),
+			})
+		case v.low > v.high:
+			errs = append(errs, &ValidationError{
+				Kind:    ValidationInvertedBounds,
+				Target:  v.name,
+				Message: fmt.Sprintf("grove: variable %q has empty domain [%g, %g] (low > high)", v.name, v.low, v.high),
+			})
 		}
 	}
+
 	if len(p.objective) == 0 {
-		return fmt.Errorf("grove: problem %q has no objective (call SetObjective)", p.name)
-	}
-	for _, c := range p.constraints {
-		if math.IsNaN(c.rhs) {
-			return fmt.Errorf("grove: constraint %q has NaN right-hand side", c.name)
-		}
-		if math.IsInf(c.rhs, 0) {
-			return fmt.Errorf("grove: constraint %q has infinite right-hand side", c.name)
-		}
-		if len(c.expr) == 0 {
-			return fmt.Errorf("grove: constraint %q has empty left-hand side", c.name)
-		}
-		for v, coef := range c.expr {
+		errs = append(errs, &ValidationError{
+			Kind:    ValidationNoObjective,
+			Message: fmt.Sprintf("grove: problem %q has no objective (call SetObjective)", p.name),
+		})
+	} else {
+		nonZero := 0
+		for v, coef := range p.objective {
 			if math.IsNaN(coef) || math.IsInf(coef, 0) {
-				return fmt.Errorf("grove: constraint %q has non-finite coefficient on %q", c.name, v.name)
+				errs = append(errs, &ValidationError{
+					Kind:    ValidationBadObjectiveCoef,
+					Target:  v.name,
+					Message: fmt.Sprintf("grove: objective has non-finite coefficient on %q", v.name),
+				})
+				continue
+			}
+			if coef != 0 {
+				nonZero++
 			}
 		}
+		if nonZero == 0 {
+			errs = append(errs, &ValidationError{
+				Kind:    ValidationZeroObjective,
+				Message: fmt.Sprintf("grove: problem %q has an all-zero objective (SetObjective needs at least one non-zero coefficient)", p.name),
+			})
+		}
 	}
-	return nil
+
+	// Duplicate constraint names: walk the slice so we still catch
+	// collisions if a caller reaches past AddConstraint (which panics
+	// on duplicates at registration time). Reporting here means
+	// Validate is the single source of truth for a model audit.
+	seen := make(map[string]int, len(p.constraints))
+	for _, c := range p.constraints {
+		seen[c.name]++
+	}
+	// Report duplicates in stable declaration order.
+	reported := make(map[string]bool, len(seen))
+	for _, c := range p.constraints {
+		n := seen[c.name]
+		if n <= 1 || reported[c.name] {
+			continue
+		}
+		reported[c.name] = true
+		errs = append(errs, &ValidationError{
+			Kind:    ValidationDuplicateConstraint,
+			Target:  c.name,
+			Message: fmt.Sprintf("grove: constraint name %q is used by %d constraints (names must be unique)", c.name, n),
+		})
+	}
+
+	for _, c := range p.constraints {
+		switch {
+		case math.IsNaN(c.rhs):
+			errs = append(errs, &ValidationError{
+				Kind:    ValidationBadRHS,
+				Target:  c.name,
+				Message: fmt.Sprintf("grove: constraint %q has NaN right-hand side", c.name),
+			})
+		case math.IsInf(c.rhs, 0):
+			errs = append(errs, &ValidationError{
+				Kind:    ValidationBadRHS,
+				Target:  c.name,
+				Message: fmt.Sprintf("grove: constraint %q has infinite right-hand side", c.name),
+			})
+		}
+
+		if len(c.expr) == 0 {
+			errs = append(errs, &ValidationError{
+				Kind:    ValidationEmptyRow,
+				Target:  c.name,
+				Message: fmt.Sprintf("grove: constraint %q has empty left-hand side", c.name),
+			})
+			continue
+		}
+
+		hasNonZero := false
+		for v, coef := range c.expr {
+			if math.IsNaN(coef) || math.IsInf(coef, 0) {
+				errs = append(errs, &ValidationError{
+					Kind:    ValidationBadCoefficient,
+					Target:  c.name,
+					Message: fmt.Sprintf("grove: constraint %q has non-finite coefficient on %q", c.name, v.name),
+				})
+				continue
+			}
+			if coef != 0 {
+				hasNonZero = true
+			}
+		}
+		if !hasNonZero {
+			errs = append(errs, &ValidationError{
+				Kind:    ValidationZeroRow,
+				Target:  c.name,
+				Message: fmt.Sprintf("grove: constraint %q has an all-zero left-hand side", c.name),
+			})
+		}
+	}
+
+	return errs
 }
 
 // Result is the outcome of a solve.
@@ -498,7 +675,8 @@ func (r *Result) Reduced(v *Var) float64 {
 // integrality before returning, and this warning will fall silent
 // whenever the model is a pure LP or the ILP is solved exactly.
 func (p *Problem) Solve() (*Result, error) {
-	if err := p.Validate(); err != nil {
+	if verrs := p.Validate(); len(verrs) > 0 {
+		err := errors.Join(verrs...)
 		return &Result{Status: NotSolved, Message: err.Error()}, err
 	}
 

--- a/presolve.go
+++ b/presolve.go
@@ -229,16 +229,11 @@ func (p *Problem) Presolve(opts *PresolveOptions) (*Problem, *PresolveUndo, erro
 		}
 		redObj[revVarMap[v]] = k
 	}
-	// The simplex driver asks every column for its objective
-	// coefficient; if every original coefficient was on a fixed
-	// variable we fold into the constant and the reduced objective
-	// map ends up empty. Put a zero term on the first surviving
-	// variable so the reduced model still has a non-empty objective
-	// expression (Validate skips the reduced problem, but the solver
-	// core indexes into the map directly).
-	if len(redObj) == 0 {
-		redObj[rp.vars[0]] = 0
-	}
+	// If every original objective term was on a fixed variable, redObj
+	// is empty and the entire linear part lives in objConst. The
+	// standard-form builder only ranges over p.objective, so an empty
+	// map is fine; Validate allows it on reduced problems via
+	// allowEmptyObjective.
 	rp.SetObjective(redObj)
 	rp.SetObjectiveConstant(p.objConst + objShift)
 	undo.objShift = objShift
@@ -272,6 +267,7 @@ func newReducedProblem(p *Problem) *Problem {
 	rp.Verbose = p.Verbose
 	rp.MaxIterations = p.MaxIterations
 	rp.SkipPresolve = true // don't recursively presolve the reduced model
+	rp.allowEmptyObjective = true
 	return rp
 }
 

--- a/presolve.go
+++ b/presolve.go
@@ -229,9 +229,13 @@ func (p *Problem) Presolve(opts *PresolveOptions) (*Problem, *PresolveUndo, erro
 		}
 		redObj[revVarMap[v]] = k
 	}
-	// Validate() insists on a non-empty objective; if every coefficient
-	// was on a fixed variable, put a zero term on the first surviving
-	// variable so the reduced model still validates.
+	// The simplex driver asks every column for its objective
+	// coefficient; if every original coefficient was on a fixed
+	// variable we fold into the constant and the reduced objective
+	// map ends up empty. Put a zero term on the first surviving
+	// variable so the reduced model still has a non-empty objective
+	// expression (Validate skips the reduced problem, but the solver
+	// core indexes into the map directly).
 	if len(redObj) == 0 {
 		redObj[rp.vars[0]] = 0
 	}

--- a/presolve_test.go
+++ b/presolve_test.go
@@ -189,6 +189,30 @@ func TestPresolveObjectiveOnlyVariable(t *testing.T) {
 	}
 }
 
+// TestPresolveReducedProblemEmptyObjectiveValidates: when every
+// linear objective term is on a variable eliminated by presolve, the
+// reduced problem has an empty objective map and cost only in
+// ObjectiveConstant; it must still pass Validate.
+func TestPresolveReducedProblemEmptyObjectiveValidates(t *testing.T) {
+	p := NewProblem("fold_all_obj", Maximize)
+	x := p.NewVar("x", Continuous)
+	y := p.NewVar("y", Continuous)
+	k := p.NewVar("k", Continuous, Bounds(0, 7))
+	p.SetObjective(Expr{k: 3})
+	p.AddConstraint("cap", Expr{x: 1, y: 1}, LTE, 10)
+
+	rp, _, err := p.Presolve(nil)
+	if err != nil {
+		t.Fatalf("Presolve: %v", err)
+	}
+	if len(rp.Objective()) != 0 {
+		t.Fatalf("want empty reduced objective map, got len=%d", len(rp.Objective()))
+	}
+	if errs := rp.Validate(); len(errs) != 0 {
+		t.Fatalf("Validate(reduced): %v", errs)
+	}
+}
+
 // TestPresolveObjectiveOnlyUnbounded: a free variable that only
 // appears in the objective proves unboundedness without touching the
 // simplex.

--- a/problem_test.go
+++ b/problem_test.go
@@ -111,11 +111,12 @@ func TestValidateBoundsInverted(t *testing.T) {
 	if len(errs) == 0 {
 		t.Fatal("expected inverted-bounds error")
 	}
-	if !hasValidationKind(errs, ValidationInvertedBounds) {
+	ve := validationErrorForKind(errs, ValidationInvertedBounds)
+	if ve == nil {
 		t.Fatalf("errs=%v want ValidationInvertedBounds", errs)
 	}
-	if !strings.Contains(errs[0].Error(), "empty domain") {
-		t.Fatalf("message=%q", errs[0].Error())
+	if !strings.Contains(ve.Message, "empty domain") {
+		t.Fatalf("message=%q", ve.Message)
 	}
 }
 
@@ -131,18 +132,27 @@ func TestValidateNaNCoefficient(t *testing.T) {
 	if !hasValidationKind(errs, ValidationBadCoefficient) {
 		t.Fatalf("errs=%v want ValidationBadCoefficient", errs)
 	}
+	if hasValidationKind(errs, ValidationZeroRow) {
+		t.Fatalf("did not want ValidationZeroRow when row has only non-finite coefs: %v", errs)
+	}
 }
 
 // hasValidationKind reports whether errs contains a *ValidationError
 // with the given Kind.
 func hasValidationKind(errs []error, k ValidationErrorKind) bool {
+	return validationErrorForKind(errs, k) != nil
+}
+
+// validationErrorForKind returns the first *ValidationError in errs with
+// the given Kind, or nil.
+func validationErrorForKind(errs []error, k ValidationErrorKind) *ValidationError {
 	for _, err := range errs {
 		var ve *ValidationError
 		if errors.As(err, &ve) && ve.Kind == k {
-			return true
+			return ve
 		}
 	}
-	return false
+	return nil
 }
 
 func TestValidateDuplicateConstraintName(t *testing.T) {
@@ -219,6 +229,21 @@ func TestValidateInfObjectiveCoefficient(t *testing.T) {
 	p.SetObjective(Expr{x: math.Inf(1)})
 	p.AddConstraint("c", Expr{x: 1}, GTE, 0)
 	errs := p.Validate()
+	if !hasValidationKind(errs, ValidationBadObjectiveCoef) {
+		t.Fatalf("errs=%v want ValidationBadObjectiveCoef", errs)
+	}
+}
+
+func TestValidateObjectiveNonFiniteOnlyNoZeroObjective(t *testing.T) {
+	p := NewProblem("p", Minimize)
+	x := p.NewVar("x", Continuous)
+	y := p.NewVar("y", Continuous)
+	p.SetObjective(Expr{x: math.NaN(), y: math.Inf(1)})
+	p.AddConstraint("c", Expr{x: 1}, GTE, 0)
+	errs := p.Validate()
+	if hasValidationKind(errs, ValidationZeroObjective) {
+		t.Fatalf("did not want ValidationZeroObjective alongside only non-finite objective coefs: %v", errs)
+	}
 	if !hasValidationKind(errs, ValidationBadObjectiveCoef) {
 		t.Fatalf("errs=%v want ValidationBadObjectiveCoef", errs)
 	}

--- a/problem_test.go
+++ b/problem_test.go
@@ -107,8 +107,15 @@ func TestValidateBoundsInverted(t *testing.T) {
 	x := p.NewVar("x", Continuous, Bounds(5, 1))
 	p.SetObjective(Expr{x: 1})
 	p.AddConstraint("c", Expr{x: 1}, GTE, 0)
-	if err := p.Validate(); err == nil || !strings.Contains(err.Error(), "empty domain") {
-		t.Fatalf("err=%v", err)
+	errs := p.Validate()
+	if len(errs) == 0 {
+		t.Fatal("expected inverted-bounds error")
+	}
+	if !hasValidationKind(errs, ValidationInvertedBounds) {
+		t.Fatalf("errs=%v want ValidationInvertedBounds", errs)
+	}
+	if !strings.Contains(errs[0].Error(), "empty domain") {
+		t.Fatalf("message=%q", errs[0].Error())
 	}
 }
 
@@ -117,8 +124,146 @@ func TestValidateNaNCoefficient(t *testing.T) {
 	x := p.NewVar("x", Continuous)
 	p.SetObjective(Expr{x: 1})
 	p.AddConstraint("c", Expr{x: math.NaN()}, GTE, 0)
-	if err := p.Validate(); err == nil {
+	errs := p.Validate()
+	if len(errs) == 0 {
 		t.Fatal("expected NaN error")
+	}
+	if !hasValidationKind(errs, ValidationBadCoefficient) {
+		t.Fatalf("errs=%v want ValidationBadCoefficient", errs)
+	}
+}
+
+// hasValidationKind reports whether errs contains a *ValidationError
+// with the given Kind.
+func hasValidationKind(errs []error, k ValidationErrorKind) bool {
+	for _, err := range errs {
+		var ve *ValidationError
+		if errors.As(err, &ve) && ve.Kind == k {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateDuplicateConstraintName(t *testing.T) {
+	// AddConstraint panics on duplicates, so simulate the scenario a
+	// file reader or direct slice manipulation could hit.
+	p := NewProblem("p", Minimize)
+	x := p.NewVar("x", Continuous)
+	p.SetObjective(Expr{x: 1})
+	p.AddConstraint("c", Expr{x: 1}, GTE, 0)
+	// Manually append a second constraint named "c" to bypass the
+	// registration-time panic.
+	p.constraints = append(p.constraints, &Constraint{
+		name:  "c",
+		expr:  Expr{x: 1},
+		ctype: LTE,
+		rhs:   5,
+		idx:   len(p.constraints),
+	})
+	errs := p.Validate()
+	if !hasValidationKind(errs, ValidationDuplicateConstraint) {
+		t.Fatalf("errs=%v want ValidationDuplicateConstraint", errs)
+	}
+}
+
+func TestValidateEmptyRow(t *testing.T) {
+	p := NewProblem("p", Minimize)
+	x := p.NewVar("x", Continuous)
+	p.SetObjective(Expr{x: 1})
+	p.AddConstraint("empty", Expr{}, LTE, 0)
+	errs := p.Validate()
+	if !hasValidationKind(errs, ValidationEmptyRow) {
+		t.Fatalf("errs=%v want ValidationEmptyRow", errs)
+	}
+}
+
+func TestValidateZeroRow(t *testing.T) {
+	p := NewProblem("p", Minimize)
+	x := p.NewVar("x", Continuous)
+	y := p.NewVar("y", Continuous)
+	p.SetObjective(Expr{x: 1})
+	p.AddConstraint("zero", Expr{x: 0, y: 0}, LTE, 0)
+	errs := p.Validate()
+	if !hasValidationKind(errs, ValidationZeroRow) {
+		t.Fatalf("errs=%v want ValidationZeroRow", errs)
+	}
+}
+
+func TestValidateZeroObjective(t *testing.T) {
+	p := NewProblem("p", Minimize)
+	x := p.NewVar("x", Continuous)
+	y := p.NewVar("y", Continuous)
+	p.SetObjective(Expr{x: 0, y: 0})
+	p.AddConstraint("c", Expr{x: 1}, GTE, 0)
+	errs := p.Validate()
+	if !hasValidationKind(errs, ValidationZeroObjective) {
+		t.Fatalf("errs=%v want ValidationZeroObjective", errs)
+	}
+}
+
+func TestValidateNaNObjectiveCoefficient(t *testing.T) {
+	p := NewProblem("p", Minimize)
+	x := p.NewVar("x", Continuous)
+	p.SetObjective(Expr{x: math.NaN()})
+	p.AddConstraint("c", Expr{x: 1}, GTE, 0)
+	errs := p.Validate()
+	if !hasValidationKind(errs, ValidationBadObjectiveCoef) {
+		t.Fatalf("errs=%v want ValidationBadObjectiveCoef", errs)
+	}
+}
+
+func TestValidateInfObjectiveCoefficient(t *testing.T) {
+	p := NewProblem("p", Minimize)
+	x := p.NewVar("x", Continuous)
+	p.SetObjective(Expr{x: math.Inf(1)})
+	p.AddConstraint("c", Expr{x: 1}, GTE, 0)
+	errs := p.Validate()
+	if !hasValidationKind(errs, ValidationBadObjectiveCoef) {
+		t.Fatalf("errs=%v want ValidationBadObjectiveCoef", errs)
+	}
+}
+
+func TestValidateInfCoefficient(t *testing.T) {
+	p := NewProblem("p", Minimize)
+	x := p.NewVar("x", Continuous)
+	p.SetObjective(Expr{x: 1})
+	p.AddConstraint("c", Expr{x: math.Inf(-1)}, LTE, 1)
+	errs := p.Validate()
+	if !hasValidationKind(errs, ValidationBadCoefficient) {
+		t.Fatalf("errs=%v want ValidationBadCoefficient", errs)
+	}
+}
+
+// TestValidateCollectsAllErrors confirms Validate never short-circuits:
+// a pathological problem should yield at least four independent errors
+// from a single call.
+func TestValidateCollectsAllErrors(t *testing.T) {
+	p := NewProblem("p", Minimize)
+	// Inverted bounds on x.
+	x := p.NewVar("x", Continuous, Bounds(5, 1))
+	// All-zero objective.
+	p.SetObjective(Expr{x: 0})
+	// Empty-row constraint.
+	p.AddConstraint("empty", Expr{}, LTE, 0)
+	// NaN coefficient.
+	p.AddConstraint("nan", Expr{x: math.NaN()}, LTE, 0)
+	// Duplicate constraint name (manually).
+	p.constraints = append(p.constraints, &Constraint{
+		name: "empty", expr: Expr{x: 1}, ctype: LTE, rhs: 0,
+		idx: len(p.constraints),
+	})
+	errs := p.Validate()
+	for _, want := range []ValidationErrorKind{
+		ValidationInvertedBounds,
+		ValidationZeroObjective,
+		ValidationEmptyRow,
+		ValidationBadCoefficient,
+		ValidationDuplicateConstraint,
+	} {
+		if !hasValidationKind(errs, want) {
+			t.Errorf("missing %s in %v", want, errs)
+		}
 	}
 }
 

--- a/solver_test.go
+++ b/solver_test.go
@@ -259,7 +259,7 @@ func TestDegenerateBland(t *testing.T) {
 // TestValidateNoVars: build a problem with no variables.
 func TestValidateNoVars(t *testing.T) {
 	p := NewProblem("empty", Minimize)
-	if err := p.Validate(); err == nil {
+	if errs := p.Validate(); len(errs) == 0 {
 		t.Fatal("want error")
 	}
 }
@@ -268,7 +268,7 @@ func TestValidateNoVars(t *testing.T) {
 func TestValidateNoObjective(t *testing.T) {
 	p := NewProblem("noobj", Minimize)
 	p.NewVar("x", Continuous)
-	if err := p.Validate(); err == nil {
+	if errs := p.Validate(); len(errs) == 0 {
 		t.Fatal("want error")
 	}
 }


### PR DESCRIPTION
- Problem.Validate returns []error with *ValidationError kinds; no short-circuit
- Duplicate constraint names, empty/zero LHS rows, all-zero objective, NaN/Inf in objective and constraints
- Solve joins validation errors via errors.Join
- Docs: modeling Validation subsection, api-reference, ROADMAP tick for #6