### PR TITLE
Add sensitivity ranging analysis (ObjCoefRange and RHSRange)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ Target: **Q3.** Backwards-compatible additions only. Epic: [#24](https://github.
   next so models can flow in from MIPLIB benchmarks).
   - [x] [#1](https://github.com/JakenHerman/grove/issues/1) CPLEX LP
   - [x] [#2](https://github.com/JakenHerman/grove/issues/2) MPS
-- Range information for sensitivity: per-coefficient and per-RHS ranges
+- [x] Range information for sensitivity: per-coefficient and per-RHS ranges
   over which the current basis stays optimal (Bertsimas & Tsitsiklis §5.2).
   ([#3](https://github.com/JakenHerman/grove/issues/3))
 - Solution warm-starting: `Solver` interface gains `SolveWith(prob,

--- a/docs/guide/api-reference.html
+++ b/docs/guide/api-reference.html
@@ -442,6 +442,14 @@
           <p>Reduced cost of <code>v</code>: per-unit objective change if <code>v</code> were forced into the basis. Zero on basic variables at a non-degenerate optimum.</p>
         </div>
         <div class="def">
+          <span class="sig">func (r *Result) ObjCoefRange(v *Var) ObjCoefRange</span>
+          <p>Closed interval of values <code>v</code>&rsquo;s objective coefficient may take while the current optimal basis remains optimal — the v0.2 ranging output of Bertsimas &amp; Tsitsiklis §5.2. Reported in the user objective sense; either endpoint may be <code>±Inf</code>. Returns the (-Inf, +Inf) sentinel for variables that didn&rsquo;t reach the simplex (e.g. presolved-fixed variables).</p>
+        </div>
+        <div class="def">
+          <span class="sig">func (r *Result) RHSRange(c *Constraint) RHSRange</span>
+          <p>Closed interval of values <code>c</code>&rsquo;s right-hand side may take while the current optimal basis stays primal-feasible (and optimal). Reported in the user RHS units; either endpoint may be <code>±Inf</code>. Returns the (-Inf, +Inf) sentinel for constraints dropped by presolve.</p>
+        </div>
+        <div class="def">
           <span class="sig">func (r *Result) NonIntegerIntegerVars(p *Problem) []*Var</span>
           <p>Integer/Binary variables whose optimum came back non-integer (within a <code>1e-6</code> tolerance). <code>nil</code> if the problem is all-continuous or the solve was not <code>Optimal</code>.</p>
         </div>
@@ -464,26 +472,40 @@
         <div class="def">
           <span class="sig">type ConstraintSensitivity struct {
   Constraint *Constraint
-  LHS        float64 // a·x at the optimum
-  Slack      float64 // LTE: b − a·x; GTE: a·x − b; EQ: 0
-  Dual       float64 // ∂z*/∂rhs
-  Binding    bool    // Slack ≈ 0
+  LHS        float64  // a·x at the optimum
+  Slack      float64  // LTE: b − a·x; GTE: a·x − b; EQ: 0
+  Dual       float64  // ∂z*/∂rhs
+  Binding    bool     // Slack ≈ 0
+  RHSRange   RHSRange // basis-stability interval for the RHS
 }</span>
-          <p>Per-constraint diagnostics block.</p>
+          <p>Per-constraint diagnostics block. <code>RHSRange</code> reports the closed interval of right-hand-side values over which the current basis stays primal-feasible (and the dual stays exact).</p>
         </div>
         <div class="def">
           <span class="sig">type VarSensitivity struct {
-  Var     *Var
-  Value   float64
-  Reduced float64
-  AtLower bool
-  AtUpper bool
+  Var          *Var
+  Value        float64
+  Reduced      float64
+  AtLower      bool
+  AtUpper      bool
+  ObjCoefRange ObjCoefRange // basis-stability interval for the obj coefficient
 }</span>
-          <p>Per-variable diagnostics block. <code>AtLower</code>/<code>AtUpper</code> indicate which bound the variable sits on, if any.</p>
+          <p>Per-variable diagnostics block. <code>AtLower</code>/<code>AtUpper</code> indicate which bound the variable sits on, if any. <code>ObjCoefRange</code> reports the closed interval of objective coefficients over which the current basis stays optimal.</p>
+        </div>
+        <div class="def">
+          <span class="sig">type ObjCoefRange struct {
+  Lo, Hi float64
+}</span>
+          <p>Closed interval (in user objective sense) of values an objective coefficient can take while the current optimal basis stays optimal. Either endpoint may be <code>±Inf</code> for a half-line. Bertsimas &amp; Tsitsiklis §5.2.</p>
+        </div>
+        <div class="def">
+          <span class="sig">type RHSRange struct {
+  Lo, Hi float64
+}</span>
+          <p>Closed interval (in user RHS units) of values a constraint&rsquo;s right-hand side can take while the current optimal basis stays primal-feasible. Either endpoint may be <code>±Inf</code> for a half-line. Bertsimas &amp; Tsitsiklis §5.2.</p>
         </div>
         <div class="def">
           <span class="sig">func (s *Sensitivity) String() string</span>
-          <p>Pretty-printed report grouped into binding constraints, slack constraints, and variables.</p>
+          <p>Pretty-printed two-table report: one row per constraint (lhs, rhs, slack, dual, binding, rhs-lo, rhs-hi) and one row per variable (value, reduced, bound-status, coef-lo, coef-hi).</p>
         </div>
       </div>
 

--- a/docs/guide/sensitivity.html
+++ b/docs/guide/sensitivity.html
@@ -171,30 +171,38 @@ fmt.Println(rep)
 
       <p>
         It prints two tables — one row per constraint, one row per
-        variable — each with the primal values and the dual / reduced
-        cost numbers side by side:
+        variable — each with the primal values, the dual / reduced
+        cost numbers, and (since v0.2) the basis-stability range
+        for the constraint&rsquo;s RHS or the variable&rsquo;s
+        objective coefficient:
       </p>
 
 <pre><code>Constraints
-  name                       lhs        rhs        slack       dual    binding
-  day_min                   12.5 GTE       4        8.5          0    false
-  night_min                    2 GTE       2          0          1     true
-  budget                   18000 LTE   18000          0   0.000833     true
+  name                       lhs        rhs        slack       dual    binding     rhs-lo     rhs-hi
+  day_min                   12.5  &gt;=         4        8.5          0    false       -inf       12.5
+  night_min                    2  &gt;=         2          0      -0.25     true          0        8.8
+  budget                   18000  &lt;=     18000          0  0.0008333     true       7800       +inf
 Variables
-  name                        value     reduced    bound-status
-  day                          12.5          0     at lower
-  night                           2          0     at lower
+  name                        value     reduced    bound-status     coef-lo    coef-hi
+  day                          12.5          0    interior            0.8       +inf
+  night                           2          0    interior           -inf       1.25
 </code></pre>
 
       <p>
         The numbers depend on the model; the shape is always this.
+        Range columns marked <code>+inf</code> / <code>-inf</code> are
+        half-lines: the corresponding side is unbounded for the
+        current basis.
+      </p>
+
+      <p>
         If you want the data instead of the prose,
         <code>SensitivityReport</code> returns a
         <code>*Sensitivity</code> whose fields are flat slices:
       </p>
 
 <pre><code class="language-go">type Sensitivity struct {
-    Constraints []ConstraintSensitivity // one entry per constraint, with a Binding bool
+    Constraints []ConstraintSensitivity // one entry per constraint
     Variables   []VarSensitivity        // one entry per variable
 }
 </code></pre>
@@ -205,44 +213,112 @@ Variables
         dashboard shape you want.
       </p>
 
-      <h2>A worked example</h2>
+      <h2>Ranging</h2>
 
       <p>
-        Given the nurse model, say the CFO finds another $2,000 in
-        the couch cushions. Before grove was in the picture, you
-        would re-solve. You don&rsquo;t have to:
+        Duals and reduced costs answer the question
+        &ldquo;how does the optimum change for an
+        <em>infinitesimal</em> perturbation?&rdquo;. Ranging answers the
+        follow-on: &ldquo;over what interval is that linear answer
+        exact?&rdquo;. Outside the interval the optimal basis flips,
+        a different constraint binds, and the slope (dual or reduced
+        cost) takes a new value.
       </p>
 
-<pre><code class="language-go">extraBudget := 2000.0
-deltaZ      := res.Dual(budget) * extraBudget
-fmt.Printf("With +$%v of budget, z* increases by %.3f\n", extraBudget, deltaZ)
+      <p>
+        grove computes two ranging quantities at the optimum, one per
+        decision variable and one per constraint:
+      </p>
+
+      <ul>
+        <li><strong><code>ObjCoefRange</code></strong> — the closed interval of
+          values <code>v</code>&rsquo;s objective coefficient can take while
+          the current optimal basis stays optimal. Read it with
+          <code>res.ObjCoefRange(v)</code>.</li>
+        <li><strong><code>RHSRange</code></strong> — the closed interval of
+          values <code>c</code>&rsquo;s right-hand side can take while the
+          current optimal basis stays primal-feasible (and therefore
+          optimal — dual feasibility is unaffected by RHS changes).
+          Read it with <code>res.RHSRange(c)</code>.</li>
+      </ul>
+
+<pre><code class="language-go">rng := res.ObjCoefRange(day)
+fmt.Printf("day's coefficient can range over [%g, %g] before the basis changes\n",
+    rng.Lo, rng.Hi)
+
+rhs := res.RHSRange(budget)
+fmt.Printf("budget can range over [%g, %g]; outside that the dual jumps\n",
+    rhs.Lo, rhs.Hi)
 </code></pre>
 
       <p>
-        The caveat: this linearisation is only exact <em>within the
-        range where the current basis stays optimal</em>. If you
-        hand the CFO&rsquo;s grant into the model and re-solve, at
-        some point a different constraint starts binding and the
-        dual jumps. v0.1 doesn&rsquo;t report the basis-stability
-        range; that ships in v0.2 (see the
-        <a href="./roadmap.html">roadmap</a>). For small perturbations
-        the dual is correct.
+        Both endpoints are stated in the user objective sense and the
+        user RHS units (no internal sign flips to translate). Either
+        endpoint may be <code>±grove.Inf</code> to indicate a
+        half-line. Variables and constraints that did not survive
+        presolve report the (-Inf, +Inf) sentinel — a fixed
+        variable&rsquo;s coefficient does not influence the optimum,
+        and a redundant constraint&rsquo;s RHS only matters if it
+        leaves the half-space the dropped row was in.
+      </p>
+
+      <h3>Worked example</h3>
+
+      <p>
+        On the nurse-scheduling LP, the CFO offers another
+        <code>$2,000</code>. The dual of <code>budget</code> is
+        <code>1/1200 ≈ 0.000833</code>. Multiplying gives
+        <code>+$1.667</code> on the objective. But is the linear
+        approximation valid here?
+      </p>
+
+<pre><code class="language-go">extraBudget := 2000.0
+rhs         := res.RHSRange(budget)
+if 18000+extraBudget &gt; rhs.Hi {
+    fmt.Println("re-solve: ΔRHS exceeds the basis-stability range")
+} else {
+    fmt.Printf("safe: %v + %v stays inside [%g, %g]\n",
+        18000.0, extraBudget, rhs.Lo, rhs.Hi)
+}
+</code></pre>
+
+      <p>
+        For the example the basis-stability range on
+        <code>budget</code> is <code>[7800, +∞)</code>. Adding
+        <code>$2,000</code> stays inside, so the dual&rsquo;s
+        prediction is exact: <code>z* = 14.5 + 0.000833 · 2000 ≈
+        16.167</code>.
+      </p>
+
+      <p>
+        Mathematical background lives in Bertsimas &amp; Tsitsiklis,
+        <em>Introduction to Linear Optimization</em>, §5.2 (&ldquo;Local
+        sensitivity analysis&rdquo;). For a basic variable in row
+        <code>i</code>, raising its coefficient by Δ keeps the basis
+        optimal iff every non-basic reduced cost <code>r_k - Δ
+        · A_current[i][k] ≥ 0</code>; the smallest such Δ in each
+        direction is grove&rsquo;s <code>Hi</code>/<code>Lo</code>.
+        For an RHS perturbation along <code>e_i</code>, the basis stays
+        primal-feasible iff every basic value
+        <code>x_B[k] + Δ · (B⁻¹ e_i)[k] ≥ 0</code>.
       </p>
 
       <h2>What grove does not report (yet)</h2>
 
       <p>
-        Three things are on the roadmap but not in v0.1:
+        Two things are on the roadmap beyond v0.2:
       </p>
 
       <ul>
-        <li>Per-coefficient ranges over which the current basis stays optimal (sensitivity of the <em>objective</em> to the objective coefficient of each variable).</li>
-        <li>Per-RHS ranges over which each constraint&rsquo;s dual stays constant.</li>
         <li>Parametric sensitivity of duals to simultaneous RHS changes.</li>
+        <li>100% basis-aware ranging through presolve — fixed variables
+          and dropped redundant constraints currently report the
+          (-Inf, +Inf) sentinel rather than the exact width of their
+          per-row feasibility interval.</li>
       </ul>
 
       <p>
-        If you need any of the above today, the <code>WriteMPS</code>
+        For either of those, the <code>WriteMPS</code>
         exporter gives you a model you can pipe into a ranging-capable
         solver (GLPK&rsquo;s <code>glpsol --ranges</code>, or HiGHS).
       </p>

--- a/docs/guide/solving.html
+++ b/docs/guide/solving.html
@@ -91,9 +91,11 @@ case grove.IterationLimit, grove.NumericalError:
     Warnings   []string      // Advisory notes; v0.1 emits WarnLPRelaxationOnly when an ILP was silently relaxed
 
     // Accessor methods read the internal maps:
-    //   Value(v)   float64   value of variable v
-    //   Dual(c)    float64   shadow price of constraint c (∂z*/∂rhs)
-    //   Reduced(v) float64   reduced cost of variable v
+    //   Value(v)         float64       value of variable v
+    //   Dual(c)          float64       shadow price of constraint c (∂z*/∂rhs)
+    //   Reduced(v)       float64       reduced cost of variable v
+    //   ObjCoefRange(v)  ObjCoefRange  basis-stability interval on v's obj coefficient
+    //   RHSRange(c)      RHSRange      basis-stability interval on c's right-hand side
     //   NonIntegerIntegerVars(p) []*Var  integer/binary vars whose LP optimum is non-integer
 }
 </code></pre>

--- a/grove.go
+++ b/grove.go
@@ -621,11 +621,11 @@ type Result struct {
 	dual    map[*Constraint]float64 // shadow prices / dual values
 	reduced map[*Var]float64        // reduced costs of variables
 
-	// Ranging diagnostics (set when Status == Optimal). For variables and
-	// constraints that did not reach the simplex (e.g. presolve dropped
-	// them) the range is the half-open (-Inf, +Inf) sentinel — changing a
-	// fixed variable's coefficient or a redundant constraint's RHS does
-	// not affect the optimum.
+	// Ranging diagnostics (set when Status == Optimal). The (-Inf, +Inf)
+	// full-line interval is the "ranging not computed through presolve"
+	// sentinel — emitted for fixed variables (whose coefficient does not
+	// influence the optimum) and for redundant rows dropped by presolve
+	// (whose exact one-sided feasibility width is not computed in v0.2).
 	objCoefRange map[*Var]ObjCoefRange
 	rhsRange     map[*Constraint]RHSRange
 

--- a/grove.go
+++ b/grove.go
@@ -621,6 +621,14 @@ type Result struct {
 	dual    map[*Constraint]float64 // shadow prices / dual values
 	reduced map[*Var]float64        // reduced costs of variables
 
+	// Ranging diagnostics (set when Status == Optimal). For variables and
+	// constraints that did not reach the simplex (e.g. presolve dropped
+	// them) the range is the half-open (-Inf, +Inf) sentinel — changing a
+	// fixed variable's coefficient or a redundant constraint's RHS does
+	// not affect the optimum.
+	objCoefRange map[*Var]ObjCoefRange
+	rhsRange     map[*Constraint]RHSRange
+
 	// Iterations is the number of simplex pivots performed across both
 	// phases.
 	Iterations int
@@ -678,6 +686,44 @@ func (r *Result) Reduced(v *Var) float64 {
 		return 0
 	}
 	return r.reduced[v]
+}
+
+// ObjCoefRange returns the closed interval of values to which v's
+// objective coefficient may move while the current optimal basis stays
+// optimal. The returned interval is reported in the user objective
+// sense. For a variable absent from the result map (or any non-Optimal
+// result) ObjCoefRange returns the (-Inf, +Inf) sentinel — the answer
+// for "unconstrained by the basis".
+//
+// See Bertsimas & Tsitsiklis, "Introduction to Linear Optimization",
+// §5.2 ("Local sensitivity analysis").
+func (r *Result) ObjCoefRange(v *Var) ObjCoefRange {
+	if r == nil {
+		return ObjCoefRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
+	}
+	if rr, ok := r.objCoefRange[v]; ok {
+		return rr
+	}
+	return ObjCoefRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
+}
+
+// RHSRange returns the closed interval of values to which c's
+// right-hand side may move while the current optimal basis stays
+// primal-feasible (and therefore optimal). The interval is in the
+// user-stated RHS units. For a constraint absent from the result map
+// (or any non-Optimal result) RHSRange returns the (-Inf, +Inf)
+// sentinel.
+//
+// See Bertsimas & Tsitsiklis, "Introduction to Linear Optimization",
+// §5.2 ("Local sensitivity analysis").
+func (r *Result) RHSRange(c *Constraint) RHSRange {
+	if r == nil {
+		return RHSRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
+	}
+	if rr, ok := r.rhsRange[c]; ok {
+		return rr
+	}
+	return RHSRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
 }
 
 // Solve runs the configured solver. If [Problem.Solver] is nil the pure-Go

--- a/presolve.go
+++ b/presolve.go
@@ -332,31 +332,43 @@ func (u *PresolveUndo) expand(res *Result) *Result {
 		return res
 	}
 	out := &Result{
-		Status:     res.Status,
-		Objective:  res.Objective,
-		Iterations: res.Iterations,
-		Message:    res.Message,
-		Warnings:   append([]string(nil), res.Warnings...),
-		values:     map[*Var]float64{},
-		dual:       map[*Constraint]float64{},
-		reduced:    map[*Var]float64{},
+		Status:       res.Status,
+		Objective:    res.Objective,
+		Iterations:   res.Iterations,
+		Message:      res.Message,
+		Warnings:     append([]string(nil), res.Warnings...),
+		values:       map[*Var]float64{},
+		dual:         map[*Constraint]float64{},
+		reduced:      map[*Var]float64{},
+		objCoefRange: map[*Var]ObjCoefRange{},
+		rhsRange:     map[*Constraint]RHSRange{},
 	}
 	// Variables settled by presolve.
+	unbounded := ObjCoefRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
 	for v, val := range u.varValue {
 		out.values[v] = val
+		// A fixed variable's value doesn't react to its objective
+		// coefficient — the basis stays optimal for any cost.
+		out.objCoefRange[v] = unbounded
 	}
 	// Variables carried through from the reduced solve.
 	for rv, ov := range u.varMap {
 		out.values[ov] = res.values[rv]
 		out.reduced[ov] = res.reduced[rv]
+		out.objCoefRange[ov] = res.objCoefRange[rv]
 	}
 	// Constraints carried through from the reduced solve.
 	for rc, oc := range u.consMap {
 		out.dual[oc] = res.dual[rc]
+		out.rhsRange[oc] = res.rhsRange[rc]
 	}
-	// Dropped constraints: zero dual.
+	// Dropped constraints: zero dual, half-line RHS range. The presolve
+	// drop is exact only because 0 ⟂ rhs holds at the original RHS;
+	// reporting the per-direction width is post-1.0 work.
+	rhsUnbounded := RHSRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
 	for _, oc := range u.droppedCons {
 		out.dual[oc] = 0
+		out.rhsRange[oc] = rhsUnbounded
 	}
 	return out
 }
@@ -370,19 +382,25 @@ func (u *PresolveUndo) terminalResult() *Result {
 		return nil
 	}
 	res := &Result{
-		Status:  u.Terminal,
-		Message: u.TerminalMsg,
-		values:  map[*Var]float64{},
-		dual:    map[*Constraint]float64{},
-		reduced: map[*Var]float64{},
+		Status:       u.Terminal,
+		Message:      u.TerminalMsg,
+		values:       map[*Var]float64{},
+		dual:         map[*Constraint]float64{},
+		reduced:      map[*Var]float64{},
+		objCoefRange: map[*Var]ObjCoefRange{},
+		rhsRange:     map[*Constraint]RHSRange{},
 	}
 	// Variable values we know (populated on any terminal path).
+	unbounded := ObjCoefRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
 	for v, val := range u.varValue {
 		res.values[v] = val
+		res.objCoefRange[v] = unbounded
 	}
 	// Dropped constraints have zero dual on every terminal path.
+	rhsUnbounded := RHSRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
 	for _, oc := range u.droppedCons {
 		res.dual[oc] = 0
+		res.rhsRange[oc] = rhsUnbounded
 	}
 	if u.Terminal == Optimal && u.orig != nil {
 		// Compute the final objective from the original problem's

--- a/presolve.go
+++ b/presolve.go
@@ -357,20 +357,39 @@ func (u *PresolveUndo) expand(res *Result) *Result {
 		out.reduced[ov] = res.reduced[rv]
 		out.objCoefRange[ov] = res.objCoefRange[rv]
 	}
-	// Constraints carried through from the reduced solve.
+	// Constraints carried through from the reduced solve. The reduced
+	// constraint's RHS is the original RHS minus Σ(k · fixed_val) for
+	// every fixed variable substituted out of the row, so the user-facing
+	// range — stated relative to the *original* RHS — picks up the same
+	// constant offset.
 	for rc, oc := range u.consMap {
 		out.dual[oc] = res.dual[rc]
-		out.rhsRange[oc] = res.rhsRange[rc]
+		shift := oc.rhs - rc.rhs
+		rrng := res.rhsRange[rc]
+		out.rhsRange[oc] = RHSRange{
+			Lo: shiftEndpoint(rrng.Lo, shift),
+			Hi: shiftEndpoint(rrng.Hi, shift),
+		}
 	}
-	// Dropped constraints: zero dual, half-line RHS range. The presolve
-	// drop is exact only because 0 ⟂ rhs holds at the original RHS;
-	// reporting the per-direction width is post-1.0 work.
+	// Dropped constraints: zero dual, full-line "ranging not computed
+	// through presolve" sentinel. The presolve drop is exact only
+	// because 0 ⟂ rhs holds at the original RHS; reporting the
+	// per-direction feasibility width of an empty row is post-1.0 work.
 	rhsUnbounded := RHSRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
 	for _, oc := range u.droppedCons {
 		out.dual[oc] = 0
 		out.rhsRange[oc] = rhsUnbounded
 	}
 	return out
+}
+
+// shiftEndpoint adds a finite offset to a range endpoint, leaving ±Inf
+// fixed (Inf + finite is still Inf).
+func shiftEndpoint(x, shift float64) float64 {
+	if math.IsInf(x, 0) {
+		return x
+	}
+	return x + shift
 }
 
 // terminalResult synthesises a [Result] for the cases where Presolve

--- a/sensitivity.go
+++ b/sensitivity.go
@@ -31,8 +31,9 @@ type Sensitivity struct {
 
 // ObjCoefRange is the closed interval of values an objective coefficient
 // can take while the current optimal basis remains optimal. Lo or Hi may
-// be ±[Inf] for a half-line. The width [Lo, Hi] is the v0.2 ranging
-// quantity from Bertsimas & Tsitsiklis §5.2.
+// be ±[Inf] for a half-line, and the full (-Inf, +Inf) interval is the
+// "ranging not computed through presolve" sentinel. The width [Lo, Hi]
+// is the v0.2 ranging quantity from Bertsimas & Tsitsiklis §5.2.
 type ObjCoefRange struct {
 	Lo, Hi float64
 }
@@ -40,8 +41,9 @@ type ObjCoefRange struct {
 // RHSRange is the closed interval of values a constraint's right-hand
 // side can take while the current optimal basis remains primal-feasible
 // (and therefore optimal, since dual feasibility is unaffected by RHS
-// changes). Lo or Hi may be ±[Inf] for a half-line. From Bertsimas &
-// Tsitsiklis §5.2.
+// changes). Lo or Hi may be ±Inf for a half-line, and the full
+// (-Inf, +Inf) interval is the "ranging not computed through presolve"
+// sentinel. From Bertsimas & Tsitsiklis §5.2.
 type RHSRange struct {
 	Lo, Hi float64
 }
@@ -132,8 +134,9 @@ func SensitivityReport(p *Problem, r *Result) *Sensitivity {
 // The output is two tables — one per constraint, one per variable —
 // extending the v0.1 columns with the v0.2 ranging numbers (rhs-lo /
 // rhs-hi for constraints, coef-lo / coef-hi for variables) appended on
-// the right. ±Inf in any range column marks a half-line; range columns
-// are blank for entries that did not survive presolve.
+// the right. ±Inf in any range column marks a half-line; entries that
+// did not survive presolve render as the full -inf / +inf interval —
+// the "ranging not computed through presolve" sentinel.
 func (s *Sensitivity) String() string {
 	var b strings.Builder
 	b.WriteString("Constraints\n")
@@ -167,14 +170,11 @@ func (s *Sensitivity) String() string {
 	return b.String()
 }
 
-// formatRangeBound renders a range endpoint compactly: blank when the
-// bound is NaN (sentinel for "range not computed"), "+inf" / "-inf" for
-// ±Inf, and a %.4g number otherwise. Keeping +inf / -inf textual matches
-// [formatBound] used by [Problem.String].
+// formatRangeBound renders a range endpoint compactly: "+inf" / "-inf"
+// for ±Inf and a %.4g number otherwise. Keeping +inf / -inf textual
+// matches [formatBound] used by [Problem.String].
 func formatRangeBound(x float64) string {
 	switch {
-	case math.IsNaN(x):
-		return ""
 	case math.IsInf(x, 1):
 		return "+inf"
 	case math.IsInf(x, -1):

--- a/sensitivity.go
+++ b/sensitivity.go
@@ -29,6 +29,23 @@ type Sensitivity struct {
 	Variables []VarSensitivity
 }
 
+// ObjCoefRange is the closed interval of values an objective coefficient
+// can take while the current optimal basis remains optimal. Lo or Hi may
+// be ±[Inf] for a half-line. The width [Lo, Hi] is the v0.2 ranging
+// quantity from Bertsimas & Tsitsiklis §5.2.
+type ObjCoefRange struct {
+	Lo, Hi float64
+}
+
+// RHSRange is the closed interval of values a constraint's right-hand
+// side can take while the current optimal basis remains primal-feasible
+// (and therefore optimal, since dual feasibility is unaffected by RHS
+// changes). Lo or Hi may be ±[Inf] for a half-line. From Bertsimas &
+// Tsitsiklis §5.2.
+type RHSRange struct {
+	Lo, Hi float64
+}
+
 // ConstraintSensitivity is the per-constraint diagnostics block.
 //
 // Slack convention:
@@ -37,13 +54,16 @@ type Sensitivity struct {
 //   - EQ:           Slack is always 0.
 //
 // Dual is the shadow price ∂z*/∂b: how much the (user-sense) objective
-// improves per unit increase of the constraint's right-hand side.
+// improves per unit increase of the constraint's right-hand side. RHSRange
+// reports the interval over which that dual remains exact (i.e. the
+// current basis stays primal-feasible).
 type ConstraintSensitivity struct {
 	Constraint *Constraint
 	LHS        float64
 	Slack      float64
 	Dual       float64
 	Binding    bool
+	RHSRange   RHSRange
 }
 
 // VarSensitivity is the per-variable diagnostics block. Reduced cost
@@ -51,13 +71,15 @@ type ConstraintSensitivity struct {
 // reduced cost on a non-basic variable at its lower bound says "raising
 // this variable's coefficient by Δ raises the objective by Δ·value once
 // the variable enters the basis"; for minimization the sign convention is
-// reversed.
+// reversed. ObjCoefRange reports the interval of objective coefficients
+// over which the current optimal basis remains optimal.
 type VarSensitivity struct {
-	Var     *Var
-	Value   float64
-	Reduced float64
-	AtLower bool
-	AtUpper bool
+	Var          *Var
+	Value        float64
+	Reduced      float64
+	AtLower      bool
+	AtUpper      bool
+	ObjCoefRange ObjCoefRange
 }
 
 // SensitivityReport assembles a [Sensitivity] from a problem and its
@@ -88,35 +110,44 @@ func SensitivityReport(p *Problem, r *Result) *Sensitivity {
 			Slack:      slack,
 			Dual:       r.Dual(c),
 			Binding:    math.Abs(slack) <= tol,
+			RHSRange:   r.RHSRange(c),
 		})
 	}
 	for _, v := range p.vars {
 		val := r.Value(v)
 		out.Variables = append(out.Variables, VarSensitivity{
-			Var:     v,
-			Value:   val,
-			Reduced: r.Reduced(v),
-			AtLower: !math.IsInf(v.low, -1) && math.Abs(val-v.low) <= tol,
-			AtUpper: !math.IsInf(v.high, 1) && math.Abs(val-v.high) <= tol,
+			Var:          v,
+			Value:        val,
+			Reduced:      r.Reduced(v),
+			AtLower:      !math.IsInf(v.low, -1) && math.Abs(val-v.low) <= tol,
+			AtUpper:      !math.IsInf(v.high, 1) && math.Abs(val-v.high) <= tol,
+			ObjCoefRange: r.ObjCoefRange(v),
 		})
 	}
 	return out
 }
 
 // String renders a Sensitivity report as a human-readable table.
+//
+// The output is two tables — one per constraint, one per variable —
+// extending the v0.1 columns with the v0.2 ranging numbers (rhs-lo /
+// rhs-hi for constraints, coef-lo / coef-hi for variables) appended on
+// the right. ±Inf in any range column marks a half-line; range columns
+// are blank for entries that did not survive presolve.
 func (s *Sensitivity) String() string {
 	var b strings.Builder
 	b.WriteString("Constraints\n")
-	b.WriteString("  name                       lhs        rhs        slack       dual    binding\n")
+	b.WriteString("  name                       lhs        rhs        slack       dual    binding     rhs-lo     rhs-hi\n")
 	cons := append([]ConstraintSensitivity(nil), s.Constraints...)
 	sort.SliceStable(cons, func(i, j int) bool { return cons[i].Constraint.idx < cons[j].Constraint.idx })
 	for _, c := range cons {
-		fmt.Fprintf(&b, "  %-22s %10.4g %3s %10.4g %10.4g %10.4g %8v\n",
+		fmt.Fprintf(&b, "  %-22s %10.4g %3s %10.4g %10.4g %10.4g %8v %10s %10s\n",
 			c.Constraint.name, c.LHS, c.Constraint.ctype, c.Constraint.rhs,
-			c.Slack, c.Dual, c.Binding)
+			c.Slack, c.Dual, c.Binding,
+			formatRangeBound(c.RHSRange.Lo), formatRangeBound(c.RHSRange.Hi))
 	}
 	b.WriteString("Variables\n")
-	b.WriteString("  name                        value     reduced    bound-status\n")
+	b.WriteString("  name                        value     reduced    bound-status     coef-lo    coef-hi\n")
 	vars := append([]VarSensitivity(nil), s.Variables...)
 	sort.SliceStable(vars, func(i, j int) bool { return vars[i].Var.idx < vars[j].Var.idx })
 	for _, v := range vars {
@@ -129,7 +160,25 @@ func (s *Sensitivity) String() string {
 		case v.AtUpper:
 			status = "at upper"
 		}
-		fmt.Fprintf(&b, "  %-24s %10.4g %10.4g    %s\n", v.Var.name, v.Value, v.Reduced, status)
+		fmt.Fprintf(&b, "  %-24s %10.4g %10.4g    %-12s %10s %10s\n",
+			v.Var.name, v.Value, v.Reduced, status,
+			formatRangeBound(v.ObjCoefRange.Lo), formatRangeBound(v.ObjCoefRange.Hi))
 	}
 	return b.String()
+}
+
+// formatRangeBound renders a range endpoint compactly: blank when the
+// bound is NaN (sentinel for "range not computed"), "+inf" / "-inf" for
+// ±Inf, and a %.4g number otherwise. Keeping +inf / -inf textual matches
+// [formatBound] used by [Problem.String].
+func formatRangeBound(x float64) string {
+	switch {
+	case math.IsNaN(x):
+		return ""
+	case math.IsInf(x, 1):
+		return "+inf"
+	case math.IsInf(x, -1):
+		return "-inf"
+	}
+	return fmt.Sprintf("%.4g", x)
 }

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 // approxEqTight is a 1e-9 comparator. Range computations from a clean
-// optimal basis come out to machine precision; the looser eps is for
-// solver-iteration artifacts in problems that may have multiple optima.
+// optimal basis come out to machine precision, so we tighten well past
+// the 1e-6 tolerance the broader solver tests use.
 func approxEqTight(a, b float64) bool {
 	switch {
 	case math.IsInf(a, 1) && math.IsInf(b, 1):
@@ -219,6 +219,75 @@ func TestRangingDualBoundedRangesMin(t *testing.T) {
 	r2 := r.RHSRange(c2)
 	if !approxEqTight(r2.Lo, 4) || !approxEqTight(r2.Hi, 12) {
 		t.Errorf("RHSRange(c2) = [%.12g, %.12g], want [4, 12]", r2.Lo, r2.Hi)
+	}
+}
+
+// TestRangingPresolveRHSOffset is a regression test for the bug where a
+// constraint's user-facing RHS range was reported in *reduced* RHS units
+// when presolve substituted a fixed variable into the row. The reduced
+// constraint has rhs' = rhs - Σ(k · fixed_val); the user-facing range
+// must be stated in the original RHS units.
+//
+// The model below has a ≥ constraint that mentions a fixed variable. The
+// reduced row drops the fixed term and shifts the RHS down by 5; the
+// user-facing range must shift back up.
+func TestRangingPresolveRHSOffset(t *testing.T) {
+	// Two equivalent models:
+	//   (1) one with a fixed variable that presolve will eliminate
+	//   (2) the same LP with the fixed variable already substituted out
+	// Their RHS ranges, reported in user RHS units, must agree.
+
+	// Model with fixed variable.
+	pFixed := NewProblem("fixed", Minimize)
+	a := pFixed.NewVar("a", Continuous, Bounds(5, 5)) // fixed at 5
+	b := pFixed.NewVar("b", Continuous, Bounds(0, Inf))
+	c := pFixed.NewVar("c", Continuous, Bounds(0, Inf))
+	pFixed.SetObjective(Expr{a: 1, b: 1, c: 2})
+	cFixed := pFixed.AddConstraint("mix", Expr{a: 1, b: 1, c: 1}, GTE, 8)
+	pFixed.AddConstraint("c-min", Expr{c: 1}, GTE, 1)
+
+	rFixed, err := pFixed.Solve()
+	if err != nil || rFixed.Status != Optimal {
+		t.Fatalf("fixed-model solve: %v %v", rFixed.Status, err)
+	}
+
+	// Equivalent model: a is gone; "mix" becomes b + c ≥ 3 (8 - 5).
+	pSub := NewProblem("sub", Minimize)
+	bSub := pSub.NewVar("b", Continuous, Bounds(0, Inf))
+	cSub := pSub.NewVar("c", Continuous, Bounds(0, Inf))
+	pSub.SetObjective(Expr{bSub: 1, cSub: 2})
+	pSub.SetObjectiveConstant(5) // a's contribution
+	cSubMix := pSub.AddConstraint("mix", Expr{bSub: 1, cSub: 1}, GTE, 3)
+	pSub.AddConstraint("c-min", Expr{cSub: 1}, GTE, 1)
+
+	rSub, err := pSub.Solve()
+	if err != nil || rSub.Status != Optimal {
+		t.Fatalf("sub-model solve: %v %v", rSub.Status, err)
+	}
+
+	// Sanity: same primal values, same objective.
+	if !approxEqTight(rFixed.Objective, rSub.Objective) {
+		t.Fatalf("objectives diverge: %g vs %g", rFixed.Objective, rSub.Objective)
+	}
+
+	// The user-facing RHS range on "mix" must be stated against the
+	// original RHS (8), not the reduced RHS (3). Translation: shift =
+	// rSub.RHSRange(cSubMix) + 5.
+	got := rFixed.RHSRange(cFixed)
+	want := rSub.RHSRange(cSubMix)
+	if !approxEqTight(got.Lo, want.Lo+5) {
+		t.Errorf("RHSRange.Lo = %.12g, want %.12g (reduced %.12g + 5)",
+			got.Lo, want.Lo+5, want.Lo)
+	}
+	if !approxEqTight(got.Hi, want.Hi+5) {
+		t.Errorf("RHSRange.Hi = %.12g, want %.12g (reduced %.12g + 5)",
+			got.Hi, want.Hi+5, want.Hi)
+	}
+
+	// And the range must include the original RHS itself.
+	if got.Lo > 8 || got.Hi < 8 {
+		t.Errorf("RHSRange = [%.12g, %.12g] does not contain original RHS 8",
+			got.Lo, got.Hi)
 	}
 }
 

--- a/sensitivity_test.go
+++ b/sensitivity_test.go
@@ -1,0 +1,290 @@
+package grove
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// approxEqTight is a 1e-9 comparator. Range computations from a clean
+// optimal basis come out to machine precision; the looser eps is for
+// solver-iteration artifacts in problems that may have multiple optima.
+func approxEqTight(a, b float64) bool {
+	switch {
+	case math.IsInf(a, 1) && math.IsInf(b, 1):
+		return true
+	case math.IsInf(a, -1) && math.IsInf(b, -1):
+		return true
+	case math.IsInf(a, 0) || math.IsInf(b, 0):
+		return false
+	case math.IsNaN(a) || math.IsNaN(b):
+		return false
+	}
+	return math.Abs(a-b) <= 1e-9*(1+math.Abs(b))
+}
+
+// TestRangingTextbookMaxLP reproduces the classical 2D max-LP example
+// worked through by hand against Bertsimas & Tsitsiklis §5.2.
+//
+//	max  5 x + 4 y
+//	s.t. 6 x + 4 y ≤ 24       (c1)
+//	     1 x + 2 y ≤ 6        (c2)
+//	     x, y ≥ 0
+//
+// Optimum: x = 3, y = 1.5, obj = 21. Optimal basis is {x, y}.
+//
+// Hand-derived ranges (all closed intervals):
+//   - obj coef x ∈ [2, 6]
+//   - obj coef y ∈ [10/3, 10]
+//   - rhs c1 ∈ [12, 36]
+//   - rhs c2 ∈ [4, 12]
+//
+// The basis stays optimal across each interval.
+func TestRangingTextbookMaxLP(t *testing.T) {
+	p := NewProblem("range-max", Maximize)
+	x := p.NewVar("x", Continuous, Bounds(0, Inf))
+	y := p.NewVar("y", Continuous, Bounds(0, Inf))
+	p.SetObjective(Expr{x: 5, y: 4})
+	c1 := p.AddConstraint("c1", Expr{x: 6, y: 4}, LTE, 24)
+	c2 := p.AddConstraint("c2", Expr{x: 1, y: 2}, LTE, 6)
+
+	r, err := p.Solve()
+	if err != nil || r.Status != Optimal {
+		t.Fatalf("solve: status=%v err=%v", r.Status, err)
+	}
+
+	// Sanity-check the optimum so a basis change up-stack is caught early.
+	if !approxEqTight(r.Objective, 21) {
+		t.Fatalf("obj = %.12g, want 21", r.Objective)
+	}
+	if !approxEqTight(r.Value(x), 3) || !approxEqTight(r.Value(y), 1.5) {
+		t.Fatalf("(x,y)=(%g, %g), want (3, 1.5)", r.Value(x), r.Value(y))
+	}
+
+	type expCoef struct {
+		v      *Var
+		lo, hi float64
+	}
+	for _, want := range []expCoef{
+		{x, 2, 6},
+		{y, 10.0 / 3.0, 10},
+	} {
+		got := r.ObjCoefRange(want.v)
+		if !approxEqTight(got.Lo, want.lo) || !approxEqTight(got.Hi, want.hi) {
+			t.Errorf("ObjCoefRange(%s) = [%.12g, %.12g], want [%.12g, %.12g]",
+				want.v.Name(), got.Lo, got.Hi, want.lo, want.hi)
+		}
+	}
+
+	type expRhs struct {
+		c      *Constraint
+		lo, hi float64
+	}
+	for _, want := range []expRhs{
+		{c1, 12, 36},
+		{c2, 4, 12},
+	} {
+		got := r.RHSRange(want.c)
+		if !approxEqTight(got.Lo, want.lo) || !approxEqTight(got.Hi, want.hi) {
+			t.Errorf("RHSRange(%s) = [%.12g, %.12g], want [%.12g, %.12g]",
+				want.c.Name(), got.Lo, got.Hi, want.lo, want.hi)
+		}
+	}
+}
+
+// TestRangingTextbookMinLP exercises a min-sense problem with a GTE
+// constraint and a binding lower-bound row (B&T §5.2 conventions).
+//
+//	min 3 x + 2 y
+//	s.t. x + y ≥ 3            (c1)
+//	     x     ≥ 1            (c2)
+//	     x, y ≥ 0
+//
+// Optimum: x = 1, y = 2, obj = 7. Both constraints binding; basis = {x, y}.
+//
+// Hand-derived ranges:
+//   - obj coef x ∈ [2, +∞)
+//   - obj coef y ∈ [0, 3]
+//   - rhs c1 ∈ [1, +∞)
+//   - rhs c2 ∈ [0, 3]
+func TestRangingTextbookMinLP(t *testing.T) {
+	p := NewProblem("range-min", Minimize)
+	x := p.NewVar("x", Continuous, Bounds(0, Inf))
+	y := p.NewVar("y", Continuous, Bounds(0, Inf))
+	p.SetObjective(Expr{x: 3, y: 2})
+	c1 := p.AddConstraint("c1", Expr{x: 1, y: 1}, GTE, 3)
+	c2 := p.AddConstraint("c2", Expr{x: 1}, GTE, 1)
+
+	r, err := p.Solve()
+	if err != nil || r.Status != Optimal {
+		t.Fatalf("solve: status=%v err=%v", r.Status, err)
+	}
+	if !approxEqTight(r.Objective, 7) {
+		t.Fatalf("obj = %.12g, want 7", r.Objective)
+	}
+	if !approxEqTight(r.Value(x), 1) || !approxEqTight(r.Value(y), 2) {
+		t.Fatalf("(x,y) = (%g, %g), want (1, 2)", r.Value(x), r.Value(y))
+	}
+
+	tests := []struct {
+		name   string
+		got    [2]float64
+		wantLo float64
+		wantHi float64
+	}{
+		{"coef x", [2]float64{r.ObjCoefRange(x).Lo, r.ObjCoefRange(x).Hi}, 2, math.Inf(1)},
+		{"coef y", [2]float64{r.ObjCoefRange(y).Lo, r.ObjCoefRange(y).Hi}, 0, 3},
+		{"rhs c1", [2]float64{r.RHSRange(c1).Lo, r.RHSRange(c1).Hi}, 1, math.Inf(1)},
+		{"rhs c2", [2]float64{r.RHSRange(c2).Lo, r.RHSRange(c2).Hi}, 0, 3},
+	}
+	for _, tc := range tests {
+		if !approxEqTight(tc.got[0], tc.wantLo) || !approxEqTight(tc.got[1], tc.wantHi) {
+			t.Errorf("%s = [%.12g, %.12g], want [%.12g, %.12g]",
+				tc.name, tc.got[0], tc.got[1], tc.wantLo, tc.wantHi)
+		}
+	}
+}
+
+// TestRangingNonBindingConstraint pins the slack-LTE invariant: a
+// non-binding upper-bound constraint can grow without limit, and can
+// shrink down to its current LHS before the slack hits zero.
+//
+//	max 2 x + y
+//	s.t. x + y ≤ 10          (c_slack)
+//	     x     ≤ 5
+//	     y     ≤ 4
+//	     x, y ≥ 0
+//
+// Optimum: x = 5, y = 4, obj = 14, LHS(c_slack) = 9.
+func TestRangingNonBindingConstraint(t *testing.T) {
+	p := NewProblem("nonbinding", Maximize)
+	x := p.NewVar("x", Continuous, Bounds(0, Inf))
+	y := p.NewVar("y", Continuous, Bounds(0, Inf))
+	p.SetObjective(Expr{x: 2, y: 1})
+	cSlack := p.AddConstraint("cap", Expr{x: 1, y: 1}, LTE, 10)
+	p.AddConstraint("xcap", Expr{x: 1}, LTE, 5)
+	p.AddConstraint("ycap", Expr{y: 1}, LTE, 4)
+
+	r, err := p.Solve()
+	if err != nil || r.Status != Optimal {
+		t.Fatalf("solve: %v %v", r.Status, err)
+	}
+	if !approxEqTight(r.Objective, 14) {
+		t.Fatalf("obj=%g, want 14", r.Objective)
+	}
+
+	got := r.RHSRange(cSlack)
+	if !approxEqTight(got.Lo, 9) {
+		t.Errorf("non-binding RHS lo = %.12g, want 9 (current LHS)", got.Lo)
+	}
+	if !math.IsInf(got.Hi, 1) {
+		t.Errorf("non-binding RHS hi = %g, want +Inf", got.Hi)
+	}
+}
+
+// TestRangingDualBoundedRanges checks the symmetric LP from the maximize
+// test in min form (manual sense flip): the same primal optimum, the
+// same ranges, but stated from the minimization side.
+func TestRangingDualBoundedRangesMin(t *testing.T) {
+	// min -5 x - 4 y s.t. same constraints. Same optimum (x=3, y=1.5),
+	// objective = -21. Ranges are reported in user-objective sense, so
+	// they invert relative to the max formulation: a coefficient of -5
+	// on x can move within [-6, -2] (i.e. the inverted [2, 6]).
+	p := NewProblem("range-min-mirror", Minimize)
+	x := p.NewVar("x", Continuous, Bounds(0, Inf))
+	y := p.NewVar("y", Continuous, Bounds(0, Inf))
+	p.SetObjective(Expr{x: -5, y: -4})
+	c1 := p.AddConstraint("c1", Expr{x: 6, y: 4}, LTE, 24)
+	c2 := p.AddConstraint("c2", Expr{x: 1, y: 2}, LTE, 6)
+
+	r, err := p.Solve()
+	if err != nil || r.Status != Optimal {
+		t.Fatalf("solve: %v %v", r.Status, err)
+	}
+	if !approxEqTight(r.Objective, -21) {
+		t.Fatalf("obj=%.12g, want -21", r.Objective)
+	}
+	rx := r.ObjCoefRange(x)
+	if !approxEqTight(rx.Lo, -6) || !approxEqTight(rx.Hi, -2) {
+		t.Errorf("ObjCoefRange(x) = [%.12g, %.12g], want [-6, -2]", rx.Lo, rx.Hi)
+	}
+	ry := r.ObjCoefRange(y)
+	if !approxEqTight(ry.Lo, -10) || !approxEqTight(ry.Hi, -10.0/3.0) {
+		t.Errorf("ObjCoefRange(y) = [%.12g, %.12g], want [-10, -10/3]", ry.Lo, ry.Hi)
+	}
+	r1 := r.RHSRange(c1)
+	if !approxEqTight(r1.Lo, 12) || !approxEqTight(r1.Hi, 36) {
+		t.Errorf("RHSRange(c1) = [%.12g, %.12g], want [12, 36]", r1.Lo, r1.Hi)
+	}
+	r2 := r.RHSRange(c2)
+	if !approxEqTight(r2.Lo, 4) || !approxEqTight(r2.Hi, 12) {
+		t.Errorf("RHSRange(c2) = [%.12g, %.12g], want [4, 12]", r2.Lo, r2.Hi)
+	}
+}
+
+// TestRangingPresolveSentinels verifies the half-line sentinel returned
+// for variables and constraints that did not survive presolve.
+func TestRangingPresolveSentinels(t *testing.T) {
+	// p has a fixed variable (low == high) that presolve will substitute
+	// out, and an empty-row constraint that presolve will drop.
+	p := NewProblem("presolve-sentinel", Minimize)
+	a := p.NewVar("a", Continuous, Bounds(2, 2)) // fixed at 2
+	b := p.NewVar("b", Continuous, Bounds(0, Inf))
+	p.SetObjective(Expr{a: 1, b: 1})
+	dropped := p.AddConstraint("dropped", Expr{a: 1}, LTE, 5) // 2 ≤ 5, redundant
+	live := p.AddConstraint("live", Expr{b: 1}, GTE, 3)
+
+	r, err := p.Solve()
+	if err != nil || r.Status != Optimal {
+		t.Fatalf("solve: %v %v", r.Status, err)
+	}
+	if got := r.ObjCoefRange(a); !math.IsInf(got.Lo, -1) || !math.IsInf(got.Hi, 1) {
+		t.Errorf("fixed var coef range = [%g, %g], want (-Inf, +Inf)", got.Lo, got.Hi)
+	}
+	if got := r.RHSRange(dropped); !math.IsInf(got.Lo, -1) || !math.IsInf(got.Hi, 1) {
+		t.Errorf("dropped constraint RHS range = [%g, %g], want (-Inf, +Inf)", got.Lo, got.Hi)
+	}
+	// live variable / constraint should report a real interval.
+	if got := r.ObjCoefRange(b); math.IsInf(got.Lo, -1) && math.IsInf(got.Hi, 1) {
+		t.Errorf("live var coef range came back unbounded; want a finite Lo")
+	}
+	if got := r.RHSRange(live); math.IsInf(got.Lo, -1) && math.IsInf(got.Hi, 1) {
+		t.Errorf("live constraint RHS range came back unbounded; want a finite endpoint")
+	}
+}
+
+// TestSensitivityStringRenderRanges checks the v0.2 String() output
+// includes both the rhs-lo/rhs-hi columns for constraints and the
+// coef-lo/coef-hi columns for variables — without breaking the v0.1
+// "two tables" shape.
+func TestSensitivityStringRenderRanges(t *testing.T) {
+	p := NewProblem("render", Maximize)
+	x := p.NewVar("x", Continuous, Bounds(0, Inf))
+	y := p.NewVar("y", Continuous, Bounds(0, Inf))
+	p.SetObjective(Expr{x: 5, y: 4})
+	p.AddConstraint("c1", Expr{x: 6, y: 4}, LTE, 24)
+	p.AddConstraint("c2", Expr{x: 1, y: 2}, LTE, 6)
+	r, err := p.Solve()
+	if err != nil || r.Status != Optimal {
+		t.Fatalf("solve: %v %v", r.Status, err)
+	}
+	rep := SensitivityReport(p, r)
+	out := rep.String()
+	for _, want := range []string{
+		"Constraints",
+		"rhs-lo",
+		"rhs-hi",
+		"Variables",
+		"coef-lo",
+		"coef-hi",
+		"x", "y", "c1", "c2",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rep.String() missing %q\n%s", want, out)
+		}
+	}
+	// Must contain exactly two table headers.
+	if strings.Count(out, "Constraints\n") != 1 || strings.Count(out, "Variables\n") != 1 {
+		t.Errorf("expected exactly two table headers; got\n%s", out)
+	}
+}

--- a/solver.go
+++ b/solver.go
@@ -74,7 +74,13 @@ func (s *SimplexSolver) Solve(p *Problem) (*Result, error) {
 		}
 	}
 
-	res := &Result{values: map[*Var]float64{}, dual: map[*Constraint]float64{}, reduced: map[*Var]float64{}}
+	res := &Result{
+		values:       map[*Var]float64{},
+		dual:         map[*Constraint]float64{},
+		reduced:      map[*Var]float64{},
+		objCoefRange: map[*Var]ObjCoefRange{},
+		rhsRange:     map[*Constraint]RHSRange{},
+	}
 
 	// ---- Phase I: minimize sum of artificials -----------------------------
 	// Bertsimas & Tsitsiklis §3.5: introduce artificial variables a_i ≥ 0
@@ -201,6 +207,59 @@ func (s *SimplexSolver) Solve(p *Problem) (*Result, error) {
 			r = -r
 		}
 		res.reduced[uv] = r
+	}
+
+	// Ranging — Bertsimas & Tsitsiklis §5.2. We compute per-internal-column
+	// objective-coefficient ranges and per-internal-row RHS ranges in the
+	// standard form, then translate back to the user model. Ranges are
+	// reported in the user objective sense and the user RHS units.
+	internalObjRanges := std.objCoefRanges(c2, rc, tol)
+	internalRHSRanges := std.rhsRanges(tol)
+
+	for _, uv := range p.vars {
+		coef := p.objective[uv]
+		lo, hi := math.Inf(-1), math.Inf(1)
+		for _, sl := range std.slotsFor[uv] {
+			s := sl.sign
+			if std.maximized {
+				s = -s
+			}
+			ir := internalObjRanges[sl.col]
+			// Internal coefficient change Δ_int = s * Δ_user; intersect
+			// the per-slot constraint into the user-Δ window.
+			var sLo, sHi float64
+			if s >= 0 {
+				sLo, sHi = ir.Lo, ir.Hi
+			} else {
+				sLo, sHi = -ir.Hi, -ir.Lo
+			}
+			if sLo > lo {
+				lo = sLo
+			}
+			if sHi < hi {
+				hi = sHi
+			}
+		}
+		res.objCoefRange[uv] = ObjCoefRange{Lo: coef + lo, Hi: coef + hi}
+	}
+
+	for _, c := range p.constraints {
+		ri, ok := std.rowOf[c]
+		if !ok {
+			// Constraint did not reach the simplex (presolve will hand
+			// the original *Constraint back via its undo map; the
+			// half-line sentinel is correct for redundant rows).
+			res.rhsRange[c] = RHSRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
+			continue
+		}
+		ir := internalRHSRanges[ri]
+		var lo, hi float64
+		if std.rowSign[ri] >= 0 {
+			lo, hi = ir.Lo, ir.Hi
+		} else {
+			lo, hi = -ir.Hi, -ir.Lo
+		}
+		res.rhsRange[c] = RHSRange{Lo: c.rhs + lo, Hi: c.rhs + hi}
 	}
 
 	if s.Verbose {
@@ -581,6 +640,113 @@ func (s *stdForm) reducedCosts(c, _ []float64) []float64 {
 		r[j] = cj - zj
 	}
 	return r
+}
+
+// internalRange is a [Lo, Hi] interval expressing how much an internal
+// coefficient (or RHS) can change while the current basis remains valid.
+// ±Inf encodes a half-line; rangeMath helpers in the SimplexSolver clip
+// these into the user model's domain.
+type internalRange struct {
+	Lo, Hi float64
+}
+
+// objCoefRanges computes, for each internal column j, the closed
+// interval [Δ_min, Δ_max] over which the cost c[j] can move while
+// keeping the basis dual-feasible (and therefore optimal — primal
+// feasibility is unaffected by objective changes). Bertsimas &
+// Tsitsiklis §5.2 ("Changes in the cost vector").
+//
+// For a basic column j (basic in row i*), every non-basic k must keep a
+// non-negative reduced cost: r_k - Δ * A_current[i*][k] ≥ 0. For a
+// non-basic column, only its own reduced cost is at stake: r_j + Δ ≥ 0.
+//
+// Artificials are reported as the (-Inf, +Inf) sentinel — their cost is
+// never user-visible.
+func (s *stdForm) objCoefRanges(c, rc []float64, tol float64) []internalRange {
+	out := make([]internalRange, s.n)
+	inBasis := make(map[int]int, s.m) // column → row
+	for i, b := range s.basis {
+		inBasis[b] = i
+	}
+	artSet := make(map[int]bool, len(s.artificials))
+	for _, j := range s.artificials {
+		artSet[j] = true
+	}
+	for j := 0; j < s.n; j++ {
+		if artSet[j] {
+			out[j] = internalRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
+			continue
+		}
+		if row, basic := inBasis[j]; basic {
+			dLo, dHi := math.Inf(-1), math.Inf(1)
+			for k := 0; k < s.n; k++ {
+				if _, isB := inBasis[k]; isB {
+					continue
+				}
+				if artSet[k] {
+					continue
+				}
+				if math.IsInf(c[k], 1) {
+					continue
+				}
+				a := s.A[row][k]
+				if math.Abs(a) <= tol {
+					continue
+				}
+				bound := rc[k] / a
+				if a > 0 {
+					if bound < dHi {
+						dHi = bound
+					}
+				} else {
+					if bound > dLo {
+						dLo = bound
+					}
+				}
+			}
+			out[j] = internalRange{Lo: dLo, Hi: dHi}
+			continue
+		}
+		// Non-basic. Reduced cost rc[j] is ≥ 0 at optimum (within tol);
+		// raising the cost only makes it more positive, lowering it by
+		// more than rc[j] makes it negative and triggers a re-pivot.
+		out[j] = internalRange{Lo: -rc[j], Hi: math.Inf(1)}
+	}
+	return out
+}
+
+// rhsRanges computes, for each row i, the closed interval [Δ_min, Δ_max]
+// over which the internal RHS b[i] can change while every basic variable
+// stays non-negative. Bertsimas & Tsitsiklis §5.2 ("Changes in the
+// requirement vector").
+//
+// The j-th basic variable's value moves to x_B[j] + Δ * (B^{-1} e_i)[j].
+// Because we kept the tableau in B^{-1}-form (A_current = B^{-1} A_orig),
+// (B^{-1} e_i)[j] is exactly A_current[j][origIdentityCol[i]].
+func (s *stdForm) rhsRanges(tol float64) []internalRange {
+	out := make([]internalRange, s.m)
+	for i := 0; i < s.m; i++ {
+		eiCol := s.origIdentityCol[i]
+		dLo, dHi := math.Inf(-1), math.Inf(1)
+		for k := 0; k < s.m; k++ {
+			a := s.A[k][eiCol]
+			if math.Abs(a) <= tol {
+				continue
+			}
+			bound := -s.b[k] / a
+			if a > 0 {
+				if bound > dLo {
+					dLo = bound
+				}
+			} else {
+				if bound < dHi {
+					dHi = bound
+				}
+			}
+		}
+		out[i] = internalRange{Lo: dLo, Hi: dHi}
+	}
+	return out
 }
 
 // basicCosts returns the cost-of-basics vector c_B with any "+∞" forbidden

--- a/solver.go
+++ b/solver.go
@@ -247,8 +247,10 @@ func (s *SimplexSolver) Solve(p *Problem) (*Result, error) {
 		ri, ok := std.rowOf[c]
 		if !ok {
 			// Constraint did not reach the simplex (presolve will hand
-			// the original *Constraint back via its undo map; the
-			// half-line sentinel is correct for redundant rows).
+			// the original *Constraint back via its undo map). Use the
+			// (-Inf, +Inf) "ranging not computed through presolve"
+			// sentinel; presolve.expand may overwrite it with the
+			// reduced-problem range adjusted for the substitution.
 			res.rhsRange[c] = RHSRange{Lo: math.Inf(-1), Hi: math.Inf(1)}
 			continue
 		}
@@ -644,8 +646,9 @@ func (s *stdForm) reducedCosts(c, _ []float64) []float64 {
 
 // internalRange is a [Lo, Hi] interval expressing how much an internal
 // coefficient (or RHS) can change while the current basis remains valid.
-// ±Inf encodes a half-line; rangeMath helpers in the SimplexSolver clip
-// these into the user model's domain.
+// ±Inf encodes a half-line; the caller (currently the post-Phase-II
+// section of [SimplexSolver.Solve]) translates these intervals back into
+// the user model's domain.
 type internalRange struct {
 	Lo, Hi float64
 }
@@ -662,6 +665,12 @@ type internalRange struct {
 //
 // Artificials are reported as the (-Inf, +Inf) sentinel — their cost is
 // never user-visible.
+//
+// Reduced costs at the optimum are ≥ 0 only within the solver's
+// tolerance, so we clamp slightly-negative values to 0 before forming
+// bounds. Without the clamp a roundoff-sized rc[k] = -1e-13 paired with
+// a positive A_current[i*][k] would yield Hi ≈ -1e-13, excluding Δ=0
+// from the range.
 func (s *stdForm) objCoefRanges(c, rc []float64, tol float64) []internalRange {
 	out := make([]internalRange, s.n)
 	inBasis := make(map[int]int, s.m) // column → row
@@ -671,6 +680,12 @@ func (s *stdForm) objCoefRanges(c, rc []float64, tol float64) []internalRange {
 	artSet := make(map[int]bool, len(s.artificials))
 	for _, j := range s.artificials {
 		artSet[j] = true
+	}
+	clampNN := func(x float64) float64 {
+		if x < 0 && x > -tol {
+			return 0
+		}
+		return x
 	}
 	for j := 0; j < s.n; j++ {
 		if artSet[j] {
@@ -693,7 +708,7 @@ func (s *stdForm) objCoefRanges(c, rc []float64, tol float64) []internalRange {
 				if math.Abs(a) <= tol {
 					continue
 				}
-				bound := rc[k] / a
+				bound := clampNN(rc[k]) / a
 				if a > 0 {
 					if bound < dHi {
 						dHi = bound
@@ -710,7 +725,7 @@ func (s *stdForm) objCoefRanges(c, rc []float64, tol float64) []internalRange {
 		// Non-basic. Reduced cost rc[j] is ≥ 0 at optimum (within tol);
 		// raising the cost only makes it more positive, lowering it by
 		// more than rc[j] makes it negative and triggers a re-pivot.
-		out[j] = internalRange{Lo: -rc[j], Hi: math.Inf(1)}
+		out[j] = internalRange{Lo: -clampNN(rc[j]), Hi: math.Inf(1)}
 	}
 	return out
 }
@@ -723,6 +738,11 @@ func (s *stdForm) objCoefRanges(c, rc []float64, tol float64) []internalRange {
 // The j-th basic variable's value moves to x_B[j] + Δ * (B^{-1} e_i)[j].
 // Because we kept the tableau in B^{-1}-form (A_current = B^{-1} A_orig),
 // (B^{-1} e_i)[j] is exactly A_current[j][origIdentityCol[i]].
+//
+// Basic values at the end of Phase II are ≥ 0 only within solver
+// tolerance; we clamp slightly-negative values to 0 before forming the
+// bound so a roundoff-sized x_B[k] = -1e-13 doesn't push Δ=0 outside
+// the returned interval.
 func (s *stdForm) rhsRanges(tol float64) []internalRange {
 	out := make([]internalRange, s.m)
 	for i := 0; i < s.m; i++ {
@@ -733,7 +753,11 @@ func (s *stdForm) rhsRanges(tol float64) []internalRange {
 			if math.Abs(a) <= tol {
 				continue
 			}
-			bound := -s.b[k] / a
+			bk := s.b[k]
+			if bk < 0 && bk > -tol {
+				bk = 0
+			}
+			bound := -bk / a
 			if a > 0 {
 				if bound > dLo {
 					dLo = bound


### PR DESCRIPTION
## Summary

This PR implements sensitivity ranging analysis for linear programs, adding the ability to compute the intervals over which objective coefficients and constraint right-hand sides can vary while maintaining the current optimal basis. This is the v0.2 ranging feature from Bertsimas & Tsitsiklis §5.2.

## Key Changes

- **New types**: Added `ObjCoefRange` and `RHSRange` structs to represent closed intervals `[Lo, Hi]` for basis-stability ranges, with support for half-lines via `±Inf` endpoints.

- **Result API extensions**: 
  - Added `Result.ObjCoefRange(v *Var)` to query the interval over which a variable's objective coefficient can move while keeping the current basis optimal
  - Added `Result.RHSRange(c *Constraint)` to query the interval over which a constraint's RHS can move while keeping the basis primal-feasible

- **Simplex solver implementation**:
  - Implemented `stdForm.objCoefRanges()` to compute per-column coefficient ranges by analyzing reduced costs of non-basic variables and the tableau structure
  - Implemented `stdForm.rhsRanges()` to compute per-row RHS ranges by analyzing basic variable values and the inverse basis representation
  - Integrated ranging computation into the main solve path, translating internal ranges back to user objective sense and RHS units

- **Sensitivity reporting**:
  - Extended `ConstraintSensitivity` with `RHSRange` field
  - Extended `VarSensitivity` with `ObjCoefRange` field
  - Updated `SensitivityReport` to populate ranging data
  - Enhanced `String()` output to display ranging columns (`rhs-lo`/`rhs-hi` for constraints, `coef-lo`/`coef-hi` for variables)
  - Added `formatRangeBound()` helper to render `±Inf` as `+inf`/`-inf` in tables

- **Presolve integration**: Updated presolve undo logic to propagate ranging data through the reduction process, assigning the `(-Inf, +Inf)` sentinel to variables and constraints that did not reach the simplex (fixed variables, dropped redundant constraints).

- **Comprehensive test suite**: Added `sensitivity_test.go` with 5 test cases covering textbook max/min LPs, non-binding constraints, dual-bounded ranges, and presolve sentinels.

- **Documentation**: Updated API reference and sensitivity guide with ranging concepts, worked examples, and mathematical background references.

## Implementation Details

- Ranging computation happens after Phase II completes, using the final tableau in `B⁻¹` form
- For basic variables: coefficient can move until a non-basic reduced cost hits zero
- For non-basic variables: coefficient can only decrease by its current reduced cost before re-pivoting
- For RHS: each basic variable's value moves by `Δ · (B⁻¹ e_i)[j]`; bounds come from keeping all basic values non-negative
- All ranges are reported in user objective sense and user RHS units (no internal sign flips)
- Tolerance-aware comparisons use `1e-9` relative epsilon for tight comparisons

https://claude.ai/code/session_011PzKEm3cxwLfg8bNL72oYn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new post-optimality computations inside the simplex solver and propagates them through presolve/Result APIs, which could affect correctness of reported sensitivity diagnostics if the ranging math or sign translations are off.
> 
> **Overview**
> Adds v0.2 *sensitivity ranging* output: `Result` now exposes `ObjCoefRange(v)` and `RHSRange(c)` (new `ObjCoefRange`/`RHSRange` interval types) to report how far objective coefficients and constraint RHS values can move while keeping the current optimal basis valid.
> 
> Implements ranging computations in the simplex solver (per-column cost ranges and per-row RHS feasibility ranges) and translates internal standard-form intervals back into user objective/RHS units; presolve expansion now carries these ranges through, using the `(-Inf, +Inf)` sentinel for fixed variables and dropped constraints.
> 
> Extends `SensitivityReport`/`Sensitivity.String()` to include the new range columns, adds a new test suite covering textbook LPs, presolve sentinels, and output rendering, and updates docs/roadmap to reflect the shipped ranging feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c90ceb596f8563fe0d1b4c79676de3d5adf0fbe8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->